### PR TITLE
Update GitHub Action runtime from Node 20 to Node 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,5 @@ inputs:
     description: 'Comma seperated string of labels to look for.'
     required: true
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'action.js'


### PR DESCRIPTION
## Summary
This pull request updates the GitHub Action runtime environment from Node.js 20 to Node.js 24.

## Changes
- Updated the `runs.using` field in `action.yml` from `node20` to `node24`

## Details
This change ensures the action runs on the latest Node.js 24 runtime, which provides access to newer language features, performance improvements, and security updates. The action logic itself remains unchanged; only the execution environment has been updated.
