### PR TITLE
Remove Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly


### PR DESCRIPTION
## Summary
This PR removes the Dependabot configuration file that was used to automatically check for updates to GitHub Actions workflows.

## Changes
- Deleted `.github/dependabot.yml` configuration file that was set to check for GitHub Actions updates on a weekly schedule

## Rationale
The removal of this configuration suggests a decision to discontinue automated dependency updates for GitHub Actions, either to reduce maintenance overhead or to shift to a manual update process.

https://claude.ai/code/session_01JZ9zMuPdEtF9omiHCTvcCL