### PR TITLE
Clarify label matching logic and add multi-set example

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This action privides a simple solution to require spesific labels on pull reques
 
 **Required** Comma seperated string of labels to look for.
 
+The check passes when the pull request has **at least one** of the listed labels (OR matching), not all of them. For example, with `bugfix, breaking-change, new-feature`, a pull request labeled with any single one of those passes. It fails only when none of the listed labels are present.
+
 ## Example usage
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Because each invocation requires **at least one** of its labels (OR matching), y
 The example below requires the pull request to have at least one **type** label (`bugfix`, `breaking-change` or `new-feature`) **and** at least one **size** label (`small`, `medium` or `large`).
 
 ```yaml
+    ...
     steps:
       - name: Check the type label
         uses: ludeeus/action-require-labels@2.0.0

--- a/README.md
+++ b/README.md
@@ -47,24 +47,6 @@ Because each invocation requires **at least one** of its labels (OR matching), y
 The example below requires the pull request to have at least one **type** label (`bugfix`, `breaking-change` or `new-feature`) **and** at least one **size** label (`small`, `medium` or `large`).
 
 ```yaml
-name: "Check Pull Request labels"
-
-on:
-  pull_request:
-    branches:
-      - main
-    types:
-      - labeled
-      - opened
-      - synchronize
-      - unlabeled
-
-permissions: {}
-
-jobs:
-  check_labels:
-    name: "Check Pull Request labels"
-    runs-on: ubuntu-latest
     steps:
       - name: Check the type label
         uses: ludeeus/action-require-labels@2.0.0

--- a/README.md
+++ b/README.md
@@ -38,3 +38,45 @@ jobs:
           labels: >-
               bugfix, breaking-change, new-feature
 ```
+
+<details>
+<summary>Requiring one of multiple sets of labels</summary>
+
+Because each invocation requires **at least one** of its labels (OR matching), you can add the action multiple times to require one label from *each* set. Every step must pass for the job to succeed, so this effectively combines the sets with AND.
+
+The example below requires the pull request to have at least one **type** label (`bugfix`, `breaking-change` or `new-feature`) **and** at least one **size** label (`small`, `medium` or `large`).
+
+```yaml
+name: "Check Pull Request labels"
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - labeled
+      - opened
+      - synchronize
+      - unlabeled
+
+permissions: {}
+
+jobs:
+  check_labels:
+    name: "Check Pull Request labels"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check the type label
+        uses: ludeeus/action-require-labels@2.0.0
+        with:
+          labels: >-
+              bugfix, breaking-change, new-feature
+
+      - name: Check the size label
+        uses: ludeeus/action-require-labels@2.0.0
+        with:
+          labels: >-
+              small, medium, large
+```
+
+</details>


### PR DESCRIPTION
## Summary
Updated the README documentation to clarify the label matching behavior and provide guidance on how to require labels from multiple sets.

## Changes
- **Clarified OR matching behavior**: Added explicit explanation that the action passes when a pull request has **at least one** of the listed labels (OR logic), not all of them, with a concrete example
- **Added multi-set label example**: Included a new collapsible section demonstrating how to use the action multiple times to require labels from different sets (combining sets with AND logic)
- **Improved documentation clarity**: Enhanced user understanding of how the action works and how to compose more complex label requirements

## Details
The documentation now clearly explains that:
- A single action invocation uses OR matching (any one label from the list passes)
- Multiple action invocations can be chained to create AND logic between sets
- This allows users to require one label from each of multiple categories (e.g., one type label AND one size label)

https://claude.ai/code/session_01T4XFw5NrPqfDU8ZfDdFwAs