### PR TITLE
Add documentation and test for inverted label checking

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,3 +25,24 @@ jobs:
         with:
           labels: >-
             bugfix, breaking-change, new-feature, dependencies, ci, documentation, internal
+
+  run_the_action_inverted:
+    name: "Run the action (inverted)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Run the local action
+        id: blocking
+        continue-on-error: true
+        uses: ./
+        with:
+          labels: >-
+            do-not-merge, wip, blocked
+
+      - name: Fail if a blocking label is present
+        if: steps.blocking.outcome == 'success'
+        run: |
+          echo "::error::A blocking label is present on the pull request."
+          exit 1

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ jobs:
               bugfix, breaking-change, new-feature
 ```
 
+## Advanced usage
+
 <details>
 <summary>Requiring one of multiple sets of labels</summary>
 
@@ -60,6 +62,33 @@ The example below requires the pull request to have at least one **type** label 
         with:
           labels: >-
               small, medium, large
+```
+
+</details>
+
+<details>
+<summary>Failing when any of the labels exist (inverted)</summary>
+
+The action passes when the pull request has **at least one** of the listed labels. To invert this — failing when **any** of the labels are present (for example to block merging on `do-not-merge`, `wip` or `blocked`) — run the action with `continue-on-error: true` to capture its outcome, then fail a follow-up step when that outcome was `success`.
+
+When the pull request has no labels at all, the action exits with a failure, so the inverted check correctly passes (no blocking label is present).
+
+```yaml
+    ...
+    steps:
+      - name: Check for blocking labels
+        id: blocking
+        continue-on-error: true
+        uses: ludeeus/action-require-labels@2.0.0
+        with:
+          labels: >-
+              do-not-merge, wip, blocked
+
+      - name: Fail if a blocking label is present
+        if: steps.blocking.outcome == 'success'
+        run: |
+          echo "::error::A blocking label is present on the pull request."
+          exit 1
 ```
 
 </details>


### PR DESCRIPTION
## Summary
This PR adds documentation and test coverage for an inverted label checking pattern, allowing users to block pull requests when specific labels are present (e.g., `do-not-merge`, `wip`, `blocked`).

## Changes
- **Documentation**: Added a new "Advanced usage" section to README.md with a detailed example showing how to use `continue-on-error: true` to invert the action's behavior and fail when blocking labels are present
- **Test workflow**: Added a new `run_the_action_inverted` job to `.github/workflows/test.yaml` that demonstrates and tests the inverted label checking pattern in practice

## Implementation Details
The inverted pattern works by:
1. Running the action with `continue-on-error: true` to capture its outcome
2. Using a follow-up step that fails when the action succeeds (indicating a blocking label was found)
3. Leveraging the fact that the action fails when no labels match, which correctly passes the inverted check

