### PR TITLE
Improve README documentation structure for advanced usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,14 @@ jobs:
 
 ## Advanced usage
 
-<details>
-<summary>Requiring one of multiple sets of labels</summary>
+### Requiring one of multiple sets of labels
 
 Because each invocation requires **at least one** of its labels (OR matching), you can add the action multiple times to require one label from *each* set. Every step must pass for the job to succeed, so this effectively combines the sets with AND.
 
 The example below requires the pull request to have at least one **type** label (`bugfix`, `breaking-change` or `new-feature`) **and** at least one **size** label (`small`, `medium` or `large`).
+
+<details>
+<summary>Example</summary>
 
 ```yaml
     ...
@@ -66,12 +68,14 @@ The example below requires the pull request to have at least one **type** label 
 
 </details>
 
-<details>
-<summary>Failing when any of the labels exist (inverted)</summary>
+### Failing when any of the labels exist (inverted)
 
 The action passes when the pull request has **at least one** of the listed labels. To invert this — failing when **any** of the labels are present (for example to block merging on `do-not-merge`, `wip` or `blocked`) — run the action with `continue-on-error: true` to capture its outcome, then fail a follow-up step when that outcome was `success`.
 
 When the pull request has no labels at all, the action exits with a failure, so the inverted check correctly passes (no blocking label is present).
+
+<details>
+<summary>Example</summary>
 
 ```yaml
     ...

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
 Add the action multiple times to require one label from *each* set (combining the sets with AND).
 
 <details>
-<summary>Example</summary>
+<summary>More details and example</summary>
 
 Because each invocation requires **at least one** of its labels (OR matching), you can add the action multiple times to require one label from *each* set. Every step must pass for the job to succeed, so this effectively combines the sets with AND.
 
@@ -75,7 +75,7 @@ The example below requires the pull request to have at least one **type** label 
 Invert the check to fail when **any** of the listed labels are present (for example to block merging on `do-not-merge`, `wip` or `blocked`).
 
 <details>
-<summary>Example</summary>
+<summary>More details and example</summary>
 
 The action passes when the pull request has **at least one** of the listed labels. To invert this — failing when **any** of the labels are present (for example to block merging on `do-not-merge`, `wip` or `blocked`) — run the action with `continue-on-error: true` to capture its outcome, then fail a follow-up step when that outcome was `success`.
 

--- a/README.md
+++ b/README.md
@@ -43,12 +43,14 @@ jobs:
 
 ### Requiring one of multiple sets of labels
 
-Because each invocation requires **at least one** of its labels (OR matching), you can add the action multiple times to require one label from *each* set. Every step must pass for the job to succeed, so this effectively combines the sets with AND.
-
-The example below requires the pull request to have at least one **type** label (`bugfix`, `breaking-change` or `new-feature`) **and** at least one **size** label (`small`, `medium` or `large`).
+Add the action multiple times to require one label from *each* set (combining the sets with AND).
 
 <details>
 <summary>Example</summary>
+
+Because each invocation requires **at least one** of its labels (OR matching), you can add the action multiple times to require one label from *each* set. Every step must pass for the job to succeed, so this effectively combines the sets with AND.
+
+The example below requires the pull request to have at least one **type** label (`bugfix`, `breaking-change` or `new-feature`) **and** at least one **size** label (`small`, `medium` or `large`).
 
 ```yaml
     ...
@@ -70,12 +72,14 @@ The example below requires the pull request to have at least one **type** label 
 
 ### Failing when any of the labels exist (inverted)
 
-The action passes when the pull request has **at least one** of the listed labels. To invert this — failing when **any** of the labels are present (for example to block merging on `do-not-merge`, `wip` or `blocked`) — run the action with `continue-on-error: true` to capture its outcome, then fail a follow-up step when that outcome was `success`.
-
-When the pull request has no labels at all, the action exits with a failure, so the inverted check correctly passes (no blocking label is present).
+Invert the check to fail when **any** of the listed labels are present (for example to block merging on `do-not-merge`, `wip` or `blocked`).
 
 <details>
 <summary>Example</summary>
+
+The action passes when the pull request has **at least one** of the listed labels. To invert this — failing when **any** of the labels are present (for example to block merging on `do-not-merge`, `wip` or `blocked`) — run the action with `continue-on-error: true` to capture its outcome, then fail a follow-up step when that outcome was `success`.
+
+When the pull request has no labels at all, the action exits with a failure, so the inverted check correctly passes (no blocking label is present).
 
 ```yaml
     ...


### PR DESCRIPTION
## Summary
Restructured the Advanced usage section of the README to improve readability and information hierarchy by moving section headers outside of collapsible details elements.

## Key Changes
- Moved "Requiring one of multiple sets of labels" from a details summary to a standalone section header with a brief description
- Moved "Failing when any of the labels exist (inverted)" from a details summary to a standalone section header with a brief description
- Changed both details summaries from descriptive titles to "More details and example" for consistency
- Added introductory text for each section that appears before the collapsible details

## Implementation Details
This change improves the documentation structure by:
- Making section titles visible by default rather than hidden in collapsed elements
- Providing quick context about each feature before users need to expand details
- Creating a clearer visual hierarchy in the Advanced usage section
- Maintaining all existing detailed explanations and examples within the collapsible sections
