### PR TITLE
Replace ubuntu-latest with ubuntu-slim in workflow runners

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   run_the_action:
     name: "Run the action"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -28,7 +28,7 @@ jobs:
 
   run_the_action_inverted:
     name: "Run the action (inverted)"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ permissions: {}
 jobs:
   check_labels:
     name: "Check Pull Request labels"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Check the labels
         uses: ludeeus/action-require-labels@2.0.0


### PR DESCRIPTION
## Summary
Updated GitHub Actions workflow configurations to use `ubuntu-slim` instead of `ubuntu-latest` as the runner image for all jobs.

## Changes
- Updated test workflow jobs to use `ubuntu-slim` runner:
  - "Run the action" job
  - "Run the action (inverted)" job
- Updated README.md example workflow to use `ubuntu-slim` runner:
  - "Check Pull Request labels" job

## Details
This change replaces the standard `ubuntu-latest` runner image with the lighter-weight `ubuntu-slim` variant across all workflow definitions. The `ubuntu-slim` image provides a more minimal environment, which can result in faster job startup times and reduced resource consumption while still maintaining compatibility with most common CI/CD tasks.

https://claude.ai/code/session_01Vs3NBMbv3QYY4n5aiAEmac