### PR TITLE
Warn when labels input is comma-separated

### DIFF
--- a/action.js
+++ b/action.js
@@ -19,6 +19,14 @@ function runAction() {
 
     const inputLabels = process.env.INPUT_LABELS
 
+    if (inputLabels && inputLabels.includes(",")) {
+        console.log(
+            "::warning::The labels input appears to be comma-separated. " +
+            "Provide one label per line (newline-separated) instead; " +
+            "comma support is deprecated."
+        )
+    }
+
     const requiredLabels = new Set(
         (inputLabels || "").split(/[,\n]/).map(label => label.trim()).filter(Boolean)
     )

--- a/action.test.js
+++ b/action.test.js
@@ -132,3 +132,29 @@ test("throws when the required labels input is only whitespace", () => {
     stubEvent({ inputLabels: " \n , \n" });
     assert.throws(() => runAction(), /No required labels defined for the action\./);
 });
+
+test("warns when the required labels input is comma-separated", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }] } },
+        inputLabels: "bugfix,breaking-change",
+    });
+    const log = mock.method(console, "log");
+    assert.doesNotThrow(() => runAction());
+    const warned = log.mock.calls.some(call =>
+        String(call.arguments[0]).startsWith("::warning::")
+    );
+    assert.ok(warned, "expected a ::warning:: line to be logged");
+});
+
+test("does not warn for purely newline-separated input", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "breaking-change" }] } },
+        inputLabels: "bugfix\nbreaking-change\nnew-feature",
+    });
+    const log = mock.method(console, "log");
+    assert.doesNotThrow(() => runAction());
+    const warned = log.mock.calls.some(call =>
+        String(call.arguments[0]).startsWith("::warning::")
+    );
+    assert.ok(!warned, "expected no ::warning:: line to be logged");
+});


### PR DESCRIPTION
The labels input is documented as one-per-line. Comma-separated values
still work for backwards compatibility, but emit a GitHub Actions warning
to nudge users toward the newline-separated format.