### PR TITLE
Add matching_label_count output to action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,6 @@ jobs:
 
       - name: Run the local action
         id: require
-        continue-on-error: true
         uses: ./
         with:
           labels: >-

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,3 +46,27 @@ jobs:
         run: |
           echo "::error::A blocking label is present on the pull request."
           exit 1
+
+  run_the_action_priority:
+    name: "Run the action (exactly one priority label)"
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Check the priority label
+        id: priority
+        continue-on-error: true
+        uses: ./
+        with:
+          labels: >-
+            p1, p2, p3
+
+      - name: Require exactly one priority label
+        env:
+          MATCHING_LABEL_COUNT: ${{ steps.priority.outputs.matching_label_count }}
+        run: |
+          if [ "$MATCHING_LABEL_COUNT" != "1" ]; then
+            echo "::error::only one priority label allowed"
+            exit 1
+          fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,10 +21,21 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Run the local action
+        id: require
+        continue-on-error: true
         uses: ./
         with:
           labels: >-
             bugfix, breaking-change, new-feature, dependencies, ci, documentation, internal, refactor
+
+      - name: Require exactly one label
+        env:
+          MATCHING_LABEL_COUNT: ${{ steps.require.outputs.matching_label_count }}
+        run: |
+          if [ "$MATCHING_LABEL_COUNT" != "1" ]; then
+            echo "::error::only one label allowed"
+            exit 1
+          fi
 
   run_the_action_inverted:
     name: "Run the action (inverted)"
@@ -46,27 +57,3 @@ jobs:
         run: |
           echo "::error::A blocking label is present on the pull request."
           exit 1
-
-  run_the_action_priority:
-    name: "Run the action (exactly one priority label)"
-    runs-on: ubuntu-slim
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Check the priority label
-        id: priority
-        continue-on-error: true
-        uses: ./
-        with:
-          labels: >-
-            p1, p2, p3
-
-      - name: Require exactly one priority label
-        env:
-          MATCHING_LABEL_COUNT: ${{ steps.priority.outputs.matching_label_count }}
-        run: |
-          if [ "$MATCHING_LABEL_COUNT" != "1" ]; then
-            echo "::error::only one priority label allowed"
-            exit 1
-          fi

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The output is set on both the passing path and the no-match failing path (where 
 
 ## Behavior
 
-The primary result is communicated through the step's success or failure; the matching label count is additionally exposed via the [`matching_label_count` output](#matching_label_count).
+The primary result is communicated through the step's success or failure; additional details are exposed via the step's [outputs](#outputs).
 
 The step **passes** when the pull request has at least one of the configured labels.
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,17 @@ The check passes when the pull request has **at least one** of the listed labels
 
 Labels are matched against the pull request labels exactly, including casing. Whitespace around each comma-separated entry is ignored.
 
+## Outputs
+
+### `matching_label_count`
+
+The number of required labels found on the pull request.
+
+The output is set on both the passing path and the no-match failing path (where it is `0`), so it is available to later steps even when the step fails — use `continue-on-error: true` to read it after a failure. It is not set when the action fails before evaluating the labels (for example on a non-`pull_request` event or when the pull request has no labels at all).
+
 ## Behavior
 
-The result is communicated through the step's success or failure; the action has no outputs.
+The primary result is communicated through the step's success or failure; the matching label count is additionally exposed via the [`matching_label_count` output](#matching_label_count).
 
 The step **passes** when the pull request has at least one of the configured labels.
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,40 @@ The example below requires the pull request to have at least one **type** label 
 
 </details>
 
+### Requiring exactly one label
+
+Use the [`matching_label_count`](#matching_label_count) output to enforce an exact number of labels — for example exactly one priority label.
+
+<details>
+<summary>More details and example</summary>
+
+The action only checks that **at least one** of the listed labels is present, so on its own it cannot enforce "exactly one". Run it with `continue-on-error: true` and read the [`matching_label_count`](#matching_label_count) output in a follow-up step that fails when the count is not `1`. The `continue-on-error` is needed so the follow-up step still runs (and can read the output, which is `0`) when no priority label is present.
+
+Pass the output to the script as an environment variable rather than interpolating it directly into the `run:` block.
+
+```yaml
+    ...
+    steps:
+      - name: Check the priority label
+        id: priority
+        continue-on-error: true
+        uses: ludeeus/action-require-labels@2.0.0
+        with:
+          labels: >-
+              p1, p2, p3
+
+      - name: Require exactly one priority label
+        env:
+          MATCHING_LABEL_COUNT: ${{ steps.priority.outputs.matching_label_count }}
+        run: |
+          if [ "$MATCHING_LABEL_COUNT" != "1" ]; then
+            echo "::error::only one priority label allowed"
+            exit 1
+          fi
+```
+
+</details>
+
 ### Failing when any of the labels exist (inverted)
 
 Invert the check to fail when **any** of the listed labels are present (for example to block merging on `do-not-merge`, `wip` or `blocked`).

--- a/action.js
+++ b/action.js
@@ -44,12 +44,7 @@ function runAction() {
     }
 }
 
-// Sets a step output by appending "name=value" to the GITHUB_OUTPUT file (the
-// mechanism used by the node24 runtime). No-ops when GITHUB_OUTPUT is unset, so
-// local runs and tests are safe. The name must not contain "=", a newline or a
-// carriage return (any of which would break the "name=value" format or allow
-// output injection), and the value must be single-line; either raises an error
-// rather than corrupting the output file.
+// Appends "name=value" to the GITHUB_OUTPUT file; no-op when unset.
 function setOutput(name, value) {
     const outputPath = process.env.GITHUB_OUTPUT
     if (!outputPath) {

--- a/action.js
+++ b/action.js
@@ -46,8 +46,9 @@ function runAction() {
 
 // Sets a step output by appending "name=value" to the GITHUB_OUTPUT file (the
 // mechanism used by the node24 runtime). No-ops when GITHUB_OUTPUT is unset, so
-// local runs and tests are safe. Only single-line values are supported; a
-// multi-line value raises an error rather than corrupting the output file.
+// local runs and tests are safe. Only single-line values are supported; a value
+// containing a newline or carriage return raises an error rather than corrupting
+// the output file.
 function setOutput(name, value) {
     const outputPath = process.env.GITHUB_OUTPUT
     if (!outputPath) {
@@ -57,7 +58,7 @@ function setOutput(name, value) {
     const stringValue = String(value)
 
     if (/[\r\n]/.test(stringValue)) {
-        throw new Error(`Output "${name}" must not contain a newline.`)
+        throw new Error(`Output "${name}" must not contain a newline or carriage return.`)
     }
 
     fs.appendFileSync(outputPath, `${name}=${stringValue}\n`)

--- a/action.js
+++ b/action.js
@@ -1,5 +1,4 @@
 const fs = require("node:fs")
-const crypto = require("node:crypto")
 
 function runAction() {
     const eventPath = process.env.GITHUB_EVENT_PATH
@@ -45,24 +44,23 @@ function runAction() {
     }
 }
 
-// Sets a step output by appending to the GITHUB_OUTPUT file (the mechanism used
-// by the node24 runtime). No-ops when GITHUB_OUTPUT is unset, so local runs and
-// tests are safe. Uses the heredoc/delimiter format so values are safe even when
-// they contain newlines or "=" (matches @actions/core's prepareKeyValueMessage).
+// Sets a step output by appending "name=value" to the GITHUB_OUTPUT file (the
+// mechanism used by the node24 runtime). No-ops when GITHUB_OUTPUT is unset, so
+// local runs and tests are safe. Only single-line values are supported; a
+// multi-line value raises an error rather than corrupting the output file.
 function setOutput(name, value) {
     const outputPath = process.env.GITHUB_OUTPUT
     if (!outputPath) {
         return
     }
 
-    const delimiter = `ghadelimiter_${crypto.randomUUID()}`
     const stringValue = String(value)
 
-    if (name.includes(delimiter) || stringValue.includes(delimiter)) {
-        throw new Error(`Unexpected output: name and value must not contain the delimiter "${delimiter}"`)
+    if (stringValue.includes("\n")) {
+        throw new Error(`Output "${name}" must not contain a newline.`)
     }
 
-    fs.appendFileSync(outputPath, `${name}<<${delimiter}\n${stringValue}\n${delimiter}\n`)
+    fs.appendFileSync(outputPath, `${name}=${stringValue}\n`)
 }
 
 // Workflow command data must stay on a single line; see

--- a/action.js
+++ b/action.js
@@ -56,7 +56,7 @@ function setOutput(name, value) {
 
     const stringValue = String(value)
 
-    if (stringValue.includes("\n")) {
+    if (/[\r\n]/.test(stringValue)) {
         throw new Error(`Output "${name}" must not contain a newline.`)
     }
 

--- a/action.js
+++ b/action.js
@@ -37,8 +37,20 @@ function runAction() {
     const matchingLabels = prLabels.filter(label => requiredLabels.has(label))
     console.log(`Found ${matchingLabels.length} matching label(s) on the pull request (${matchingLabels.join(",")})`)
 
+    setOutput("matching_label_count", matchingLabels.length)
+
     if (matchingLabels.length === 0) {
         throw new Error("No matching required labels found.")
+    }
+}
+
+// Sets a step output by appending to the GITHUB_OUTPUT file (the mechanism used
+// by the node24 runtime). No-ops when GITHUB_OUTPUT is unset, so local runs and
+// tests are safe. Output names and counts are single-line and need no escaping.
+function setOutput(name, value) {
+    const outputPath = process.env.GITHUB_OUTPUT
+    if (outputPath) {
+        fs.appendFileSync(outputPath, `${name}=${value}\n`)
     }
 }
 

--- a/action.js
+++ b/action.js
@@ -1,4 +1,5 @@
 const fs = require("node:fs")
+const crypto = require("node:crypto")
 
 function runAction() {
     const eventPath = process.env.GITHUB_EVENT_PATH
@@ -46,12 +47,22 @@ function runAction() {
 
 // Sets a step output by appending to the GITHUB_OUTPUT file (the mechanism used
 // by the node24 runtime). No-ops when GITHUB_OUTPUT is unset, so local runs and
-// tests are safe. Output names and counts are single-line and need no escaping.
+// tests are safe. Uses the heredoc/delimiter format so values are safe even when
+// they contain newlines or "=" (matches @actions/core's prepareKeyValueMessage).
 function setOutput(name, value) {
     const outputPath = process.env.GITHUB_OUTPUT
-    if (outputPath) {
-        fs.appendFileSync(outputPath, `${name}=${value}\n`)
+    if (!outputPath) {
+        return
     }
+
+    const delimiter = `ghadelimiter_${crypto.randomUUID()}`
+    const stringValue = String(value)
+
+    if (name.includes(delimiter) || stringValue.includes(delimiter)) {
+        throw new Error(`Unexpected output: name and value must not contain the delimiter "${delimiter}"`)
+    }
+
+    fs.appendFileSync(outputPath, `${name}<<${delimiter}\n${stringValue}\n${delimiter}\n`)
 }
 
 // Workflow command data must stay on a single line; see
@@ -69,4 +80,4 @@ if (require.main === module) {
     }
 }
 
-module.exports = { runAction }
+module.exports = { runAction, setOutput }

--- a/action.js
+++ b/action.js
@@ -46,13 +46,18 @@ function runAction() {
 
 // Sets a step output by appending "name=value" to the GITHUB_OUTPUT file (the
 // mechanism used by the node24 runtime). No-ops when GITHUB_OUTPUT is unset, so
-// local runs and tests are safe. Only single-line values are supported; a value
-// containing a newline or carriage return raises an error rather than corrupting
-// the output file.
+// local runs and tests are safe. The name must not contain "=", a newline or a
+// carriage return (any of which would break the "name=value" format or allow
+// output injection), and the value must be single-line; either raises an error
+// rather than corrupting the output file.
 function setOutput(name, value) {
     const outputPath = process.env.GITHUB_OUTPUT
     if (!outputPath) {
         return
+    }
+
+    if (/[\r\n=]/.test(name)) {
+        throw new Error(`Output name "${name}" must not contain "=", a newline or a carriage return.`)
     }
 
     const stringValue = String(value)

--- a/action.js
+++ b/action.js
@@ -51,6 +51,10 @@ function setOutput(name, value) {
         return
     }
 
+    if (!name) {
+        throw new Error("Output name must not be empty.")
+    }
+
     if (/[\r\n=]/.test(name)) {
         throw new Error(`Output name "${name}" must not contain "=", a newline or a carriage return.`)
     }

--- a/action.test.js
+++ b/action.test.js
@@ -133,14 +133,20 @@ test("writes a zero matching label count to GITHUB_OUTPUT before failing on no m
     assert.match(writes.join(""), /^matching_label_count=0\n$/);
 });
 
-test("setOutput throws when the value contains a newline", () => {
-    process.env.GITHUB_OUTPUT = "/mock/output.txt";
+for (const { label, value } of [
+    { label: "a newline", value: "line1\nline2" },
+    { label: "a carriage return", value: "line1\rline2" },
+    { label: "a carriage return and newline", value: "line1\r\nline2" },
+]) {
+    test(`setOutput throws when the value contains ${label}`, () => {
+        process.env.GITHUB_OUTPUT = "/mock/output.txt";
 
-    const appendMock = mock.method(fs, "appendFileSync", () => {});
+        const appendMock = mock.method(fs, "appendFileSync", () => {});
 
-    assert.throws(() => setOutput("example", "line1\nline2"), /must not contain a newline/);
-    assert.equal(appendMock.mock.callCount(), 0);
-});
+        assert.throws(() => setOutput("example", value), /must not contain a newline or carriage return/);
+        assert.equal(appendMock.mock.callCount(), 0);
+    });
+}
 
 test("does not write outputs when GITHUB_OUTPUT is not set", () => {
     stubEvent({

--- a/action.test.js
+++ b/action.test.js
@@ -163,6 +163,15 @@ for (const { label, name } of [
     });
 }
 
+test("setOutput throws when the name is empty", () => {
+    process.env.GITHUB_OUTPUT = "/mock/output.txt";
+
+    const appendMock = mock.method(fs, "appendFileSync", () => {});
+
+    assert.throws(() => setOutput("", "1"), /must not be empty/);
+    assert.equal(appendMock.mock.callCount(), 0);
+});
+
 test("does not write outputs when the action fails before evaluating labels", () => {
     stubEvent({ event: { push: {} } });
     process.env.GITHUB_OUTPUT = "/mock/output.txt";

--- a/action.test.js
+++ b/action.test.js
@@ -35,6 +35,7 @@ afterEach(() => {
     mock.restoreAll();
     delete process.env.GITHUB_EVENT_PATH;
     delete process.env.INPUT_LABELS;
+    delete process.env.GITHUB_OUTPUT;
 });
 
 test("throws when the event path is not set", () => {
@@ -102,4 +103,44 @@ test("trims whitespace around required labels before matching", () => {
         inputLabels: " bugfix , breaking-change , new-feature ",
     });
     assert.doesNotThrow(() => runAction());
+});
+
+test("writes the matching label count to the GITHUB_OUTPUT file on success", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }, { name: "new-feature" }, { name: "question" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+    });
+    process.env.GITHUB_OUTPUT = "/mock/output.txt";
+
+    const writes = [];
+    mock.method(fs, "appendFileSync", (_path, data) => writes.push(data));
+
+    assert.doesNotThrow(() => runAction());
+    assert.ok(writes.join("").includes("matching_label_count=2"));
+});
+
+test("writes a zero matching label count to GITHUB_OUTPUT before failing on no match", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "documentation" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+    });
+    process.env.GITHUB_OUTPUT = "/mock/output.txt";
+
+    const writes = [];
+    mock.method(fs, "appendFileSync", (_path, data) => writes.push(data));
+
+    assert.throws(() => runAction(), /No matching required labels found\./);
+    assert.ok(writes.join("").includes("matching_label_count=0"));
+});
+
+test("does not write outputs when GITHUB_OUTPUT is not set", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }] } },
+        inputLabels: "bugfix",
+    });
+
+    const appendMock = mock.method(fs, "appendFileSync", () => {});
+
+    assert.doesNotThrow(() => runAction());
+    assert.equal(appendMock.mock.callCount(), 0);
 });

--- a/action.test.js
+++ b/action.test.js
@@ -1,8 +1,9 @@
 const { test, mock, afterEach } = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
+const crypto = require("node:crypto");
 
-const { runAction } = require("./action.js");
+const { runAction, setOutput } = require("./action.js");
 
 // Stubs the filesystem and environment that runAction reads. Nothing here
 // touches the real filesystem (fs is mocked) and the env values are
@@ -116,7 +117,7 @@ test("writes the matching label count to the GITHUB_OUTPUT file on success", () 
     mock.method(fs, "appendFileSync", (_path, data) => writes.push(data));
 
     assert.doesNotThrow(() => runAction());
-    assert.ok(writes.join("").includes("matching_label_count=2"));
+    assert.match(writes.join(""), /^matching_label_count<<(ghadelimiter_\S+)\n2\n\1\n$/m);
 });
 
 test("writes a zero matching label count to GITHUB_OUTPUT before failing on no match", () => {
@@ -130,7 +131,26 @@ test("writes a zero matching label count to GITHUB_OUTPUT before failing on no m
     mock.method(fs, "appendFileSync", (_path, data) => writes.push(data));
 
     assert.throws(() => runAction(), /No matching required labels found\./);
-    assert.ok(writes.join("").includes("matching_label_count=0"));
+    assert.match(writes.join(""), /^matching_label_count<<(ghadelimiter_\S+)\n0\n\1\n$/m);
+});
+
+test("setOutput wraps multi-line values between matching delimiters", () => {
+    process.env.GITHUB_OUTPUT = "/mock/output.txt";
+
+    const writes = [];
+    mock.method(fs, "appendFileSync", (_path, data) => writes.push(data));
+
+    setOutput("example", "line1\nline2");
+
+    assert.match(writes.join(""), /^example<<(ghadelimiter_\S+)\nline1\nline2\n\1\n$/);
+});
+
+test("setOutput throws when the value contains the generated delimiter", () => {
+    process.env.GITHUB_OUTPUT = "/mock/output.txt";
+    mock.method(crypto, "randomUUID", () => "fixed");
+    mock.method(fs, "appendFileSync", () => {});
+
+    assert.throws(() => setOutput("example", "before ghadelimiter_fixed after"), /delimiter/);
 });
 
 test("does not write outputs when GITHUB_OUTPUT is not set", () => {

--- a/action.test.js
+++ b/action.test.js
@@ -1,7 +1,6 @@
 const { test, mock, afterEach } = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
-const crypto = require("node:crypto");
 
 const { runAction, setOutput } = require("./action.js");
 
@@ -117,7 +116,7 @@ test("writes the matching label count to the GITHUB_OUTPUT file on success", () 
     mock.method(fs, "appendFileSync", (_path, data) => writes.push(data));
 
     assert.doesNotThrow(() => runAction());
-    assert.match(writes.join(""), /^matching_label_count<<(ghadelimiter_\S+)\n2\n\1\n$/m);
+    assert.match(writes.join(""), /^matching_label_count=2\n$/);
 });
 
 test("writes a zero matching label count to GITHUB_OUTPUT before failing on no match", () => {
@@ -131,26 +130,16 @@ test("writes a zero matching label count to GITHUB_OUTPUT before failing on no m
     mock.method(fs, "appendFileSync", (_path, data) => writes.push(data));
 
     assert.throws(() => runAction(), /No matching required labels found\./);
-    assert.match(writes.join(""), /^matching_label_count<<(ghadelimiter_\S+)\n0\n\1\n$/m);
+    assert.match(writes.join(""), /^matching_label_count=0\n$/);
 });
 
-test("setOutput wraps multi-line values between matching delimiters", () => {
+test("setOutput throws when the value contains a newline", () => {
     process.env.GITHUB_OUTPUT = "/mock/output.txt";
 
-    const writes = [];
-    mock.method(fs, "appendFileSync", (_path, data) => writes.push(data));
+    const appendMock = mock.method(fs, "appendFileSync", () => {});
 
-    setOutput("example", "line1\nline2");
-
-    assert.match(writes.join(""), /^example<<(ghadelimiter_\S+)\nline1\nline2\n\1\n$/);
-});
-
-test("setOutput throws when the value contains the generated delimiter", () => {
-    process.env.GITHUB_OUTPUT = "/mock/output.txt";
-    mock.method(crypto, "randomUUID", () => "fixed");
-    mock.method(fs, "appendFileSync", () => {});
-
-    assert.throws(() => setOutput("example", "before ghadelimiter_fixed after"), /delimiter/);
+    assert.throws(() => setOutput("example", "line1\nline2"), /must not contain a newline/);
+    assert.equal(appendMock.mock.callCount(), 0);
 });
 
 test("does not write outputs when GITHUB_OUTPUT is not set", () => {

--- a/action.test.js
+++ b/action.test.js
@@ -148,6 +148,31 @@ for (const { label, value } of [
     });
 }
 
+for (const { label, name } of [
+    { label: "an equals sign", name: "bad=name" },
+    { label: "a newline", name: "bad\nname" },
+    { label: "a carriage return", name: "bad\rname" },
+]) {
+    test(`setOutput throws when the name contains ${label}`, () => {
+        process.env.GITHUB_OUTPUT = "/mock/output.txt";
+
+        const appendMock = mock.method(fs, "appendFileSync", () => {});
+
+        assert.throws(() => setOutput(name, "1"), /Output name .* must not contain "=", a newline or a carriage return/s);
+        assert.equal(appendMock.mock.callCount(), 0);
+    });
+}
+
+test("does not write outputs when the action fails before evaluating labels", () => {
+    stubEvent({ event: { push: {} } });
+    process.env.GITHUB_OUTPUT = "/mock/output.txt";
+
+    const appendMock = mock.method(fs, "appendFileSync", () => {});
+
+    assert.throws(() => runAction(), /This is not a pull request\./);
+    assert.equal(appendMock.mock.callCount(), 0);
+});
+
 test("does not write outputs when GITHUB_OUTPUT is not set", () => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "bugfix" }] } },

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   labels:
     description: 'Comma separated string of labels to look for.'
     required: true
+outputs:
+  matching_label_count:
+    description: 'The number of required labels found on the pull request.'
 runs:
   using: 'node24'
   main: 'action.js'


### PR DESCRIPTION
Adds a `matching_label_count` output to the action, exposing how many of the
required labels were found on the pull request. Until now the action only
communicated its result through step success/failure.
