### PR TITLE
Add maximum_matching_labels input to enforce upper bound on labels

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,8 +26,8 @@ jobs:
           labels: >-
             bugfix, breaking-change, new-feature, dependencies, ci, documentation, internal, refactor
 
-  run_the_action_maximum:
-    name: "Run the action (maximum)"
+  run_the_action_maximum_matching_labels:
+    name: "Run the action (maximum_matching_labels)"
     runs-on: ubuntu-slim
     steps:
       - name: Checkout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,9 +33,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      # The pull request carries more than one of these labels, so capping the
-      # allowed matches at 1 makes the action fail by design. continue-on-error
-      # keeps the job green while still exercising the cap-exceeded failure path.
       - name: Run the local action
         continue-on-error: true
         uses: ./

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,13 +33,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - name: Write a pull request event with two matching labels
+        run: echo '{"pull_request":{"labels":[{"name":"bugfix"},{"name":"new-feature"}]}}' > "${RUNNER_TEMP}/event.json"
+
       - name: Run the local action
+        id: maximum
         continue-on-error: true
+        env:
+          GITHUB_EVENT_PATH: ${{ runner.temp }}/event.json
         uses: ./
         with:
           labels: >-
-            bugfix, breaking-change, new-feature, dependencies, ci, documentation, internal, refactor
+            bugfix, breaking-change, new-feature
           maximum_matching_labels: 1
+
+      - name: Fail unless the action rejected the extra label
+        if: steps.maximum.outcome != 'failure'
+        run: |
+          echo "::error::Expected the action to fail when matching labels exceed maximum_matching_labels."
+          exit 1
 
   run_the_action_inverted:
     name: "Run the action (inverted)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,24 @@ jobs:
           labels: >-
             bugfix, breaking-change, new-feature, dependencies, ci, documentation, internal, refactor
 
+  run_the_action_maximum:
+    name: "Run the action (maximum)"
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # The pull request carries more than one of these labels, so capping the
+      # allowed matches at 1 makes the action fail by design. continue-on-error
+      # keeps the job green while still exercising the cap-exceeded failure path.
+      - name: Run the local action
+        continue-on-error: true
+        uses: ./
+        with:
+          labels: >-
+            bugfix, breaking-change, new-feature, dependencies, ci, documentation, internal, refactor
+          maximum_matching_labels: 1
+
   run_the_action_inverted:
     name: "Run the action (inverted)"
     runs-on: ubuntu-slim

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,25 +33,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Write a pull request event with two matching labels
-        run: echo '{"pull_request":{"labels":[{"name":"bugfix"},{"name":"new-feature"}]}}' > "${RUNNER_TEMP}/event.json"
-
       - name: Run the local action
-        id: maximum
-        continue-on-error: true
-        env:
-          GITHUB_EVENT_PATH: ${{ runner.temp }}/event.json
         uses: ./
         with:
           labels: >-
-            bugfix, breaking-change, new-feature
+            bugfix, breaking-change, new-feature, dependencies, ci, documentation, internal, refactor
           maximum_matching_labels: 1
-
-      - name: Fail unless the action rejected the extra label
-        if: steps.maximum.outcome != 'failure'
-        run: |
-          echo "::error::Expected the action to fail when matching labels exceed maximum_matching_labels."
-          exit 1
 
   run_the_action_inverted:
     name: "Run the action (inverted)"

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Use [`maximum_matching_labels`](#maximum_matching_labels) to require **exactly o
 <details>
 <summary>More details and example</summary>
 
-The action already requires **at least one** of the listed labels. Setting `maximum_matching_labels: 1` adds the upper bound, so the step passes only when exactly one of the labels is present — no follow-up step or `continue-on-error` needed.
+The action already requires **at least one** of the listed labels. Setting `maximum_matching_labels: 1` adds the upper bound, so the step passes only when exactly one of the labels is present.
 
 ```yaml
     ...

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ The check passes when the pull request has **at least one** of the listed labels
 
 Labels are matched against the pull request labels exactly, including casing. Whitespace around each comma-separated entry is ignored.
 
+### `maximum_matching_labels`
+
+**Optional** Maximum number of matching labels allowed on the pull request.
+
+The check fails when **more than** this many of the listed labels are present. It defaults to the number of labels supplied in [`labels`](#labels), so it is a no-op unless you set it to a lower value. Combined with the default "at least one" rule, setting it to `1` enforces **exactly one** matching label.
+
+It must be a positive integer.
+
 ## Behavior
 
 The result is communicated through the step's success or failure; the action has no outputs.
@@ -42,6 +50,7 @@ The step **passes** when the pull request has at least one of the configured lab
 The step **fails** when:
 
 - The pull request has none of the configured labels.
+- The pull request has more matching labels than [`maximum_matching_labels`](#maximum_matching_labels) allows.
 - The pull request has no labels at all.
 - The workflow was not triggered by a `pull_request` event.
 
@@ -103,6 +112,28 @@ The example below requires the pull request to have at least one **type** label 
         with:
           labels: >-
               small, medium, large
+```
+
+</details>
+
+### Requiring exactly one label
+
+Use [`maximum_matching_labels`](#maximum_matching_labels) to require **exactly one** of the listed labels — for example exactly one priority label.
+
+<details>
+<summary>More details and example</summary>
+
+The action already requires **at least one** of the listed labels. Setting `maximum_matching_labels: 1` adds the upper bound, so the step passes only when exactly one of the labels is present — no follow-up step or `continue-on-error` needed.
+
+```yaml
+    ...
+    steps:
+      - name: Require exactly one priority label
+        uses: ludeeus/action-require-labels@2.0.0
+        with:
+          labels: >-
+              p1, p2, p3
+          maximum_matching_labels: 1
 ```
 
 </details>

--- a/action.js
+++ b/action.js
@@ -31,13 +31,12 @@ function runAction() {
 
     let maximumMatchingLabels = requiredLabels.size
 
-    const inputMaximum = process.env.INPUT_MAXIMUM_MATCHING_LABELS
-    if (inputMaximum && inputMaximum.trim() !== "") {
-        const trimmedMaximum = inputMaximum.trim()
-        if (!/^\d+$/.test(trimmedMaximum) || Number(trimmedMaximum) < 1) {
+    const inputMaximum = (process.env.INPUT_MAXIMUM_MATCHING_LABELS || "").trim()
+    if (inputMaximum) {
+        if (!/^\d+$/.test(inputMaximum) || Number(inputMaximum) < 1) {
             throw new Error("maximum_matching_labels must be a positive integer.")
         }
-        maximumMatchingLabels = Number(trimmedMaximum)
+        maximumMatchingLabels = Number(inputMaximum)
     }
 
     const prLabels = eventData.pull_request.labels.map(label => label.name)

--- a/action.js
+++ b/action.js
@@ -29,7 +29,6 @@ function runAction() {
         throw new Error("No required labels defined for the action.")
     }
 
-    // Defaults to the number of supplied labels, so the cap is a no-op unless set.
     let maximumMatchingLabels = requiredLabels.size
 
     const inputMaximum = process.env.INPUT_MAXIMUM_MATCHING_LABELS

--- a/action.js
+++ b/action.js
@@ -29,6 +29,18 @@ function runAction() {
         throw new Error("No required labels defined for the action.")
     }
 
+    // Defaults to the number of supplied labels, so the cap is a no-op unless set.
+    let maximumMatchingLabels = requiredLabels.size
+
+    const inputMaximum = process.env.INPUT_MAXIMUM_MATCHING_LABELS
+    if (inputMaximum && inputMaximum.trim() !== "") {
+        const trimmedMaximum = inputMaximum.trim()
+        if (!/^\d+$/.test(trimmedMaximum) || Number(trimmedMaximum) < 1) {
+            throw new Error("maximum_matching_labels must be a positive integer.")
+        }
+        maximumMatchingLabels = Number(trimmedMaximum)
+    }
+
     const prLabels = eventData.pull_request.labels.map(label => label.name)
 
     console.log(`Required labels (${Array.from(requiredLabels).join(",")})`)
@@ -39,6 +51,10 @@ function runAction() {
 
     if (matchingLabels.length === 0) {
         throw new Error("No matching required labels found.")
+    }
+
+    if (matchingLabels.length > maximumMatchingLabels) {
+        throw new Error(`Found ${matchingLabels.length} matching label(s), but a maximum of ${maximumMatchingLabels} is allowed.`)
     }
 }
 

--- a/action.test.js
+++ b/action.test.js
@@ -158,6 +158,21 @@ for (const value of ["abc", "0", "-1", "1.5"]) {
     });
 }
 
+for (const { label, value } of [
+    { label: "empty", value: "" },
+    { label: "a single space", value: " " },
+    { label: "only whitespace", value: "            " },
+]) {
+    test(`treats ${label} maximum_matching_labels as unset and uses the default`, () => {
+        stubEvent({
+            event: { pull_request: { labels: [{ name: "bugfix" }, { name: "new-feature" }] } },
+            inputLabels: "bugfix,breaking-change,new-feature",
+            maximumMatchingLabels: value,
+        });
+        assert.doesNotThrow(() => runAction());
+    });
+}
+
 test("still throws the no-match error when no labels match, regardless of maximum_matching_labels", () => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "documentation" }] } },

--- a/action.test.js
+++ b/action.test.js
@@ -14,6 +14,7 @@ function stubEvent(opts = {}) {
     const exists = "exists" in opts ? opts.exists : true;
     const eventPath = "eventPath" in opts ? opts.eventPath : "/mock/event.json";
     const inputLabels = "inputLabels" in opts ? opts.inputLabels : "bugfix";
+    const maximumMatchingLabels = "maximumMatchingLabels" in opts ? opts.maximumMatchingLabels : undefined;
 
     mock.method(fs, "existsSync", () => exists);
     mock.method(fs, "readFileSync", () => JSON.stringify(event));
@@ -29,12 +30,19 @@ function stubEvent(opts = {}) {
     } else {
         process.env.INPUT_LABELS = inputLabels;
     }
+
+    if (maximumMatchingLabels === undefined) {
+        delete process.env.INPUT_MAXIMUM_MATCHING_LABELS;
+    } else {
+        process.env.INPUT_MAXIMUM_MATCHING_LABELS = maximumMatchingLabels;
+    }
 }
 
 afterEach(() => {
     mock.restoreAll();
     delete process.env.GITHUB_EVENT_PATH;
     delete process.env.INPUT_LABELS;
+    delete process.env.INPUT_MAXIMUM_MATCHING_LABELS;
 });
 
 test("throws when the event path is not set", () => {
@@ -102,4 +110,59 @@ test("trims whitespace around required labels before matching", () => {
         inputLabels: " bugfix , breaking-change , new-feature ",
     });
     assert.doesNotThrow(() => runAction());
+});
+
+test("passes by default when every supplied label matches (cap defaults to supplied count)", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }, { name: "breaking-change" }, { name: "new-feature" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+    });
+    assert.doesNotThrow(() => runAction());
+});
+
+test("throws when matching labels exceed maximum_matching_labels", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }, { name: "new-feature" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+        maximumMatchingLabels: "1",
+    });
+    assert.throws(() => runAction(), /Found 2 matching label\(s\), but a maximum of 1 is allowed\./);
+});
+
+test("passes when matching labels equal maximum_matching_labels (boundary, not exceeded)", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }, { name: "new-feature" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+        maximumMatchingLabels: "2",
+    });
+    assert.doesNotThrow(() => runAction());
+});
+
+test("passes with maximum_matching_labels of 1 when exactly one label matches", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }, { name: "question" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+        maximumMatchingLabels: "1",
+    });
+    assert.doesNotThrow(() => runAction());
+});
+
+for (const value of ["abc", "0", "-1", "1.5"]) {
+    test(`throws when maximum_matching_labels is "${value}"`, () => {
+        stubEvent({
+            event: { pull_request: { labels: [{ name: "bugfix" }] } },
+            inputLabels: "bugfix,breaking-change,new-feature",
+            maximumMatchingLabels: value,
+        });
+        assert.throws(() => runAction(), /maximum_matching_labels must be a positive integer\./);
+    });
+}
+
+test("still throws the no-match error when no labels match, regardless of maximum_matching_labels", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "documentation" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+        maximumMatchingLabels: "1",
+    });
+    assert.throws(() => runAction(), /No matching required labels found\./);
 });

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   labels:
     description: 'Comma separated string of labels to look for.'
     required: true
+  maximum_matching_labels:
+    description: 'Maximum number of matching labels allowed. Defaults to the number of supplied labels.'
+    required: false
 runs:
   using: 'node24'
   main: 'action.js'


### PR DESCRIPTION
## Summary
This PR adds a new optional `maximum_matching_labels` input to the action that allows users to enforce an upper bound on the number of matching labels. Combined with the existing "at least one" requirement, this enables use cases like requiring exactly one label from a set.

## Key Changes
- **New input parameter**: Added `maximum_matching_labels` to `action.yml` as an optional input that defaults to the number of supplied labels
- **Validation logic**: Implemented validation in `action.js` to ensure the input is a positive integer
- **Enforcement**: Added check to fail the action when matching labels exceed the specified maximum
- **Documentation**: Updated README with explanation of the new parameter and added example for "exactly one label" use case
- **Test coverage**: Added comprehensive test cases covering:
  - Default behavior (no cap enforcement)
  - Exceeding the maximum (failure case)
  - Boundary conditions (equal to maximum passes)
  - Invalid input validation (non-integer, zero, negative, decimal values)
  - Interaction with existing "no matching labels" error
- **CI workflow**: Added test job to verify the feature works in practice

## Implementation Details
- The maximum defaults to the count of required labels, making it a no-op unless explicitly set to a lower value
- Input validation uses regex to ensure only positive integers are accepted
- Error messages clearly indicate both the count found and the maximum allowed
- The maximum matching labels check runs after the minimum (at least one) check, so the "no matching labels" error takes precedence

https://claude.ai/code/session_0197be94KNgmsGv5RcrV2F1y