### PR TITLE
Warn when duplicate labels are supplied in input

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The action reads the pull request labels from the event payload and succeeds whe
 
 The check passes when the pull request has **at least one** of the listed labels (OR matching), not all of them. For example, with `bugfix, breaking-change, new-feature`, a pull request labeled with any single one of those passes. It fails only when none of the listed labels are present.
 
-Labels are matched against the pull request labels exactly, including casing. Whitespace around each comma-separated entry is ignored.
+Labels are matched against the pull request labels exactly, including casing. Whitespace around each comma-separated entry is ignored. Supplying the same label more than once has no effect on matching, but logs a warning so the duplicate can be cleaned up.
 
 ### `maximum_matching_labels`
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The action reads the pull request labels from the event payload and succeeds whe
 
 The check passes when the pull request has **at least one** of the listed labels (OR matching), not all of them. For example, with `bugfix, breaking-change, new-feature`, a pull request labeled with any single one of those passes. It fails only when none of the listed labels are present.
 
-Labels are matched against the pull request labels exactly, including casing. Whitespace around each comma-separated entry is ignored. Supplying the same label more than once has no effect on matching, but logs a warning so the duplicate can be cleaned up.
+Labels are matched against the pull request labels exactly, including casing. Whitespace around each comma-separated entry is ignored. Supplying the same label more than once has no effect on matching, but logs a warning so the duplicates can be cleaned up.
 
 ### `maximum_matching_labels`
 

--- a/action.js
+++ b/action.js
@@ -31,15 +31,7 @@ function runAction() {
     }
 
     if (parsedLabels.length !== requiredLabels.size) {
-        const seen = new Set()
-        const duplicates = new Set()
-        for (const label of parsedLabels) {
-            if (seen.has(label)) {
-                duplicates.add(label)
-            }
-            seen.add(label)
-        }
-        console.log(`::warning::${escapeData(`Duplicate label(s) in the labels input (${Array.from(duplicates).join(",")})`)}`)
+        console.log("::warning::The labels input contains duplicate labels.")
     }
 
     let maximumMatchingLabels = requiredLabels.size

--- a/action.js
+++ b/action.js
@@ -23,10 +23,23 @@ function runAction() {
         throw new Error("No required labels defined for the action.")
     }
 
-    const requiredLabels = new Set(inputLabels.split(",").map(label => label.trim()).filter(Boolean))
+    const parsedLabels = inputLabels.split(",").map(label => label.trim()).filter(Boolean)
+    const requiredLabels = new Set(parsedLabels)
 
     if (requiredLabels.size === 0) {
         throw new Error("No required labels defined for the action.")
+    }
+
+    if (parsedLabels.length !== requiredLabels.size) {
+        const seen = new Set()
+        const duplicates = new Set()
+        for (const label of parsedLabels) {
+            if (seen.has(label)) {
+                duplicates.add(label)
+            }
+            seen.add(label)
+        }
+        console.log(`::warning::${escapeData(`Duplicate label(s) in the labels input (${Array.from(duplicates).join(",")})`)}`)
     }
 
     let maximumMatchingLabels = requiredLabels.size

--- a/action.test.js
+++ b/action.test.js
@@ -100,7 +100,7 @@ test("warns when the same label is supplied multiple times in the input", () => 
 
     const warnings = logged.filter(line => typeof line === "string" && line.startsWith("::warning::"));
     assert.equal(warnings.length, 1);
-    assert.match(warnings[0], /Duplicate label\(s\) in the labels input \(bugfix,new-feature\)/);
+    assert.match(warnings[0], /contains duplicate labels/);
 });
 
 test("does not warn when every supplied label is unique", () => {

--- a/action.test.js
+++ b/action.test.js
@@ -88,6 +88,35 @@ test("ignores empty entries in the required labels input", () => {
     assert.doesNotThrow(() => runAction());
 });
 
+test("warns when the same label is supplied multiple times in the input", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }] } },
+        inputLabels: "bugfix,bugfix,new-feature,bugfix,new-feature",
+    });
+    const logged = [];
+    mock.method(console, "log", (msg) => logged.push(msg));
+
+    assert.doesNotThrow(() => runAction());
+
+    const warnings = logged.filter(line => typeof line === "string" && line.startsWith("::warning::"));
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /Duplicate label\(s\) in the labels input \(bugfix,new-feature\)/);
+});
+
+test("does not warn when every supplied label is unique", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+    });
+    const logged = [];
+    mock.method(console, "log", (msg) => logged.push(msg));
+
+    assert.doesNotThrow(() => runAction());
+
+    const warnings = logged.filter(line => typeof line === "string" && line.startsWith("::warning::"));
+    assert.equal(warnings.length, 0);
+});
+
 test("throws when none of the PR labels match the required labels", () => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "documentation" }, { name: "question" }] } },


### PR DESCRIPTION
## Summary
This change adds validation to detect and warn users when the same label is supplied multiple times in the `labels` input parameter. While duplicate labels don't affect the matching logic, warning users helps them clean up their configuration.

## Key Changes
- **action.js**: Added duplicate label detection that compares the length of the parsed labels array against the deduplicated Set size. When duplicates are found, a GitHub Actions warning is logged.
- **action.test.js**: Added two new test cases:
  - Test that verifies a warning is logged when duplicate labels are present
  - Test that verifies no warning is logged when all labels are unique
- **README.md**: Updated documentation to clarify that duplicate labels have no effect on matching but will trigger a warning for cleanup purposes

## Implementation Details
The duplicate detection works by:
1. Parsing the input labels into an array while trimming whitespace and filtering empty entries
2. Creating a Set from the parsed labels for deduplication
3. Comparing the array length to the Set size—if they differ, duplicates exist
4. Logging a GitHub Actions warning message when duplicates are detected

This approach is efficient and maintains backward compatibility while providing helpful feedback to users.

https://claude.ai/code/session_01SpTnJ8KLtMZty7kR9PCcBp