### PR TITLE
Distinguish expected action errors from unexpected failures

### DIFF
--- a/action.js
+++ b/action.js
@@ -85,7 +85,7 @@ if (require.main === module) {
         if (err instanceof ActionError) {
             console.log(`::error::${escapeData(err.message)}`)
         } else {
-            console.log(err)
+            console.error(err)
             console.log("::error::Unknown error")
         }
         process.exitCode = 1

--- a/action.js
+++ b/action.js
@@ -85,7 +85,6 @@ if (require.main === module) {
         if (err instanceof ActionError) {
             console.log(`::error::${escapeData(err.message)}`)
         } else {
-            console.error(err)
             console.log("::error::Unknown error")
         }
         process.exitCode = 1

--- a/action.js
+++ b/action.js
@@ -1,33 +1,37 @@
 const fs = require("node:fs")
 
+// Errors the action raises intentionally for invalid configuration or input.
+// Anything that is not an ActionError is treated as an unexpected failure.
+class ActionError extends Error {}
+
 function runAction() {
     const eventPath = process.env.GITHUB_EVENT_PATH
 
     if (!eventPath || !fs.existsSync(eventPath)) {
-        throw new Error(`GITHUB_EVENT_PATH ${eventPath} does not exist`)
+        throw new ActionError(`GITHUB_EVENT_PATH ${eventPath} does not exist`)
     }
 
     const eventData = JSON.parse(fs.readFileSync(eventPath, { encoding: 'utf8' }))
 
     if (!eventData.pull_request) {
-        throw new Error("This is not a pull request.")
+        throw new ActionError("This is not a pull request.")
     }
 
     if (!eventData.pull_request.labels || eventData.pull_request.labels.length === 0) {
-        throw new Error("No labels defined on the pull request.")
+        throw new ActionError("No labels defined on the pull request.")
     }
 
     const inputLabels = process.env.INPUT_LABELS
 
     if (!inputLabels) {
-        throw new Error("No required labels defined for the action.")
+        throw new ActionError("No required labels defined for the action.")
     }
 
     const parsedLabels = inputLabels.split(",").map(label => label.trim()).filter(Boolean)
     const requiredLabels = new Set(parsedLabels)
 
     if (requiredLabels.size === 0) {
-        throw new Error("No required labels defined for the action.")
+        throw new ActionError("No required labels defined for the action.")
     }
 
     if (parsedLabels.length !== requiredLabels.size) {
@@ -39,7 +43,7 @@ function runAction() {
     const inputMaximum = (process.env.INPUT_MAXIMUM_MATCHING_LABELS || "").trim()
     if (inputMaximum) {
         if (!/^\d+$/.test(inputMaximum) || Number(inputMaximum) < 1) {
-            throw new Error("maximum_matching_labels must be a positive integer.")
+            throw new ActionError("maximum_matching_labels must be a positive integer.")
         }
         maximumMatchingLabels = Number(inputMaximum)
     }
@@ -53,11 +57,11 @@ function runAction() {
     console.log(`Found ${matchingLabels.length} matching label(s) on the pull request (${matchingLabels.join(",")})`)
 
     if (matchingLabels.length === 0) {
-        throw new Error("No matching required labels found.")
+        throw new ActionError("No matching required labels found.")
     }
 
     if (matchingLabels.length > maximumMatchingLabels) {
-        throw new Error(`Found ${matchingLabels.length} matching label(s), but a maximum of ${maximumMatchingLabels} is allowed.`)
+        throw new ActionError(`Found ${matchingLabels.length} matching label(s), but a maximum of ${maximumMatchingLabels} is allowed.`)
     }
 }
 
@@ -71,9 +75,14 @@ if (require.main === module) {
     try {
         runAction()
     } catch (err) {
-        console.log(`::error::${escapeData(err.message || err.toString())}`)
+        if (err instanceof ActionError) {
+            console.log(`::error::${escapeData(err.message)}`)
+        } else {
+            console.log(err)
+            console.log("::error::Unknown error")
+        }
         process.exitCode = 1
     }
 }
 
-module.exports = { runAction }
+module.exports = { runAction, ActionError }

--- a/action.test.js
+++ b/action.test.js
@@ -147,8 +147,13 @@ test("failures raised by the action are ActionError instances", () => {
 });
 
 test("throws a non-ActionError when the event file is not valid JSON", () => {
-    stubEvent();
+    // Set up the fs mocks directly (rather than via stubEvent) so readFileSync
+    // is mocked exactly once with the malformed payload.
+    mock.method(fs, "existsSync", () => true);
     mock.method(fs, "readFileSync", () => "{ not json");
+    process.env.GITHUB_EVENT_PATH = "/mock/event.json";
+    process.env.INPUT_LABELS = "bugfix";
+
     assert.throws(() => runAction(), (err) => err instanceof SyntaxError && !(err instanceof ActionError));
 });
 

--- a/action.test.js
+++ b/action.test.js
@@ -2,7 +2,7 @@ const { test, mock, afterEach } = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 
-const { runAction } = require("./action.js");
+const { runAction, ActionError } = require("./action.js");
 
 // Stubs the filesystem and environment that runAction reads. Nothing here
 // touches the real filesystem (fs is mocked) and the env values are
@@ -123,6 +123,26 @@ test("throws when none of the PR labels match the required labels", () => {
         inputLabels: "bugfix,breaking-change,new-feature",
     });
     assert.throws(() => runAction(), /No matching required labels found\./);
+});
+
+test("failures raised by the action are ActionError instances", () => {
+    stubEvent({ event: { push: {} } });
+    assert.throws(() => runAction(), ActionError);
+});
+
+test("throws a non-ActionError when the event file is not valid JSON", () => {
+    stubEvent();
+    mock.method(fs, "readFileSync", () => "{ not json");
+    assert.throws(() => runAction(), (err) => err instanceof SyntaxError && !(err instanceof ActionError));
+});
+
+test("the maximum_matching_labels limit failure is an ActionError", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }, { name: "new-feature" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+        maximumMatchingLabels: "1",
+    });
+    assert.throws(() => runAction(), ActionError);
 });
 
 test("succeeds when at least one PR label matches a required label", () => {


### PR DESCRIPTION
## Summary
Introduces an `ActionError` class to distinguish the action's own **expected** failures (invalid configuration/input) from **unexpected** failures (e.g. a malformed event file), so the two categories are reported differently. This revives the idea from #42, applied across the current `action.js`.

## Key Changes
- **New `ActionError` class**: a custom error type for intentional failures caused by invalid configuration or input.
- **Error classification**: every `throw new Error()` for an expected validation/config failure is now `throw new ActionError()` — **9 instances**, including the two inside the `resolveMaximumMatchingLabelsCount()` helper.
- **Error handling** in the entry point (`require.main === module`):
  - `ActionError` → a clean `::error::<message>` annotation.
  - Any other (unexpected) error → a generic `::error::Unknown error` annotation.
- **No raw error echo**: unexpected errors intentionally do **not** print the raw error object. The error text can contain user-influenced content (event payload values, label names, paths); echoing multi-line output whose lines may start with `::` would risk **workflow-command injection**. Emitting only the fixed generic annotation avoids that entirely.
- **Unwrapped `JSON.parse`**: parsing the event file is left unwrapped on purpose — a malformed file throws a `SyntaxError`, which is exactly the "unexpected" path.
- **Exports**: `ActionError` is exported for use in tests.
- **Tests**: three type-assertion tests — action failures are `ActionError` instances, malformed event JSON throws a non-`ActionError` `SyntaxError`, and the `maximum_matching_labels` limit failure is an `ActionError`.

## Notes
This branch is merged up to date with `main` (which since #64 extracted the `maximum_matching_labels` validation into a helper). All existing message-based tests plus the new type tests pass (`node --test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012F7BuirrhhyLSpxgVChHv8