### PR TITLE
Add list of required labels to related errors

### DIFF
--- a/action.js
+++ b/action.js
@@ -13,10 +13,6 @@ function runAction() {
         throw new Error("This is not a pull request.")
     }
 
-    if (!eventData.pull_request.labels || eventData.pull_request.labels.length === 0) {
-        throw new Error("No labels defined on the pull request.")
-    }
-
     const inputLabels = process.env.INPUT_LABELS
 
     if (!inputLabels) {
@@ -44,6 +40,10 @@ function runAction() {
         maximumMatchingLabels = Number(inputMaximum)
     }
 
+    if (!eventData.pull_request.labels || eventData.pull_request.labels.length === 0) {
+        throw new Error(`No labels defined on the pull request. Required labels: ${Array.from(requiredLabels).join(", ")}.`)
+    }
+
     const prLabels = eventData.pull_request.labels.map(label => label.name)
 
     console.log(`Required labels (${Array.from(requiredLabels).join(",")})`)
@@ -53,7 +53,7 @@ function runAction() {
     console.log(`Found ${matchingLabels.length} matching label(s) on the pull request (${matchingLabels.join(",")})`)
 
     if (matchingLabels.length === 0) {
-        throw new Error("No matching required labels found.")
+        throw new Error(`No matching required labels found. Required labels: ${Array.from(requiredLabels).join(", ")}.`)
     }
 
     if (matchingLabels.length > maximumMatchingLabels) {

--- a/action.test.js
+++ b/action.test.js
@@ -61,13 +61,13 @@ test("throws when the event is not a pull request", () => {
 });
 
 test("throws when the pull request has no labels property", () => {
-    stubEvent({ event: { pull_request: {} } });
-    assert.throws(() => runAction(), /No labels defined on the pull request\./);
+    stubEvent({ event: { pull_request: {} }, inputLabels: "bugfix,new-feature" });
+    assert.throws(() => runAction(), /No labels defined on the pull request\. Required labels: bugfix, new-feature\./);
 });
 
 test("throws when the pull request has an empty labels array", () => {
-    stubEvent({ event: { pull_request: { labels: [] } } });
-    assert.throws(() => runAction(), /No labels defined on the pull request\./);
+    stubEvent({ event: { pull_request: { labels: [] } }, inputLabels: "bugfix,new-feature" });
+    assert.throws(() => runAction(), /No labels defined on the pull request\. Required labels: bugfix, new-feature\./);
 });
 
 test("throws when no required labels are defined for the action", () => {
@@ -122,7 +122,7 @@ test("throws when none of the PR labels match the required labels", () => {
         event: { pull_request: { labels: [{ name: "documentation" }, { name: "question" }] } },
         inputLabels: "bugfix,breaking-change,new-feature",
     });
-    assert.throws(() => runAction(), /No matching required labels found\./);
+    assert.throws(() => runAction(), /No matching required labels found\. Required labels: bugfix, breaking-change, new-feature\./);
 });
 
 test("succeeds when at least one PR label matches a required label", () => {
@@ -208,5 +208,5 @@ test("still throws the no-match error when no labels match, regardless of maximu
         inputLabels: "bugfix,breaking-change,new-feature",
         maximumMatchingLabels: "1",
     });
-    assert.throws(() => runAction(), /No matching required labels found\./);
+    assert.throws(() => runAction(), /No matching required labels found\. Required labels: bugfix, breaking-change, new-feature\./);
 });


### PR DESCRIPTION
Adds the list of labels to error logs where they are missing, to make it easier to identify missing labels on a PR.
