### PR TITLE
Disable credential persistence in GitHub Actions checkout steps

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Run the local action
         uses: ./
@@ -32,6 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Run the local action
         uses: ./
@@ -46,6 +50,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Run the local action
         id: blocking

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Summary
This PR disables credential persistence across all GitHub Actions checkout steps in the test and unit test workflows for improved security.

## Key Changes
- Added `persist-credentials: false` configuration to the `actions/checkout` step in `.github/workflows/test.yaml` (3 occurrences across different jobs)
- Added `persist-credentials: false` configuration to the `actions/checkout` step in `.github/workflows/unittest.yaml`

## Implementation Details
By setting `persist-credentials: false`, the checkout action will not persist the GitHub token as a git credential after the checkout is complete. This is a security best practice that:
- Reduces the risk of accidental credential leakage in subsequent workflow steps
- Prevents the token from being used in unintended git operations
- Follows the principle of least privilege for credential management

This change applies to all test jobs in both workflow files, ensuring consistent security practices across the CI/CD pipeline.

https://claude.ai/code/session_01JJThnXkf39KBedbvgg3kDM