### PR TITLE
Escape workflow command characters in logged label names

### DIFF
--- a/action.js
+++ b/action.js
@@ -46,11 +46,11 @@ function runAction() {
 
     const prLabels = eventData.pull_request.labels.map(label => label.name)
 
-    console.log(`Required labels (${Array.from(requiredLabels).join(", ")})`)
-    console.log(`Pull request labels (${prLabels.join(", ")})`)
+    console.log(`Required labels (${escapeData(Array.from(requiredLabels).join(", "))})`)
+    console.log(`Pull request labels (${escapeData(prLabels.join(", "))})`)
 
     const matchingLabels = prLabels.filter(label => requiredLabels.has(label))
-    console.log(`Found ${matchingLabels.length} matching label(s) on the pull request (${matchingLabels.join(", ")})`)
+    console.log(`Found ${matchingLabels.length} matching label(s) on the pull request (${escapeData(matchingLabels.join(", "))})`)
 
     if (matchingLabels.length === 0) {
         throw new Error(`No matching required labels found. Required labels: ${Array.from(requiredLabels).join(", ")}.`)

--- a/action.test.js
+++ b/action.test.js
@@ -117,6 +117,21 @@ test("does not warn when every supplied label is unique", () => {
     assert.equal(warnings.length, 0);
 });
 
+test("escapes workflow-command characters in label names before logging", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "50%-done" }] } },
+        inputLabels: "50%-done",
+    });
+    const logged = [];
+    mock.method(console, "log", (msg) => logged.push(msg));
+
+    assert.doesNotThrow(() => runAction());
+
+    const labelLines = logged.filter(line => typeof line === "string" && line.includes("50%25-done"));
+    assert.equal(labelLines.length, 3);
+    assert.ok(!logged.some(line => typeof line === "string" && line.includes("50%-done")));
+});
+
 test("throws when none of the PR labels match the required labels", () => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "documentation" }, { name: "question" }] } },

--- a/action.test.js
+++ b/action.test.js
@@ -119,17 +119,18 @@ test("does not warn when every supplied label is unique", () => {
 
 test("escapes workflow-command characters in label names before logging", () => {
     stubEvent({
-        event: { pull_request: { labels: [{ name: "50%-done" }] } },
-        inputLabels: "50%-done",
+        event: { pull_request: { labels: [{ name: "50%-done\r\n::error::injected" }] } },
+        inputLabels: "50%-done\r\n::error::injected",
     });
     const logged = [];
     mock.method(console, "log", (msg) => logged.push(msg));
 
     assert.doesNotThrow(() => runAction());
 
-    const labelLines = logged.filter(line => typeof line === "string" && line.includes("50%25-done"));
+    const escaped = "50%25-done%0D%0A::error::injected";
+    const labelLines = logged.filter(line => typeof line === "string" && line.includes(escaped));
     assert.equal(labelLines.length, 3);
-    assert.ok(!logged.some(line => typeof line === "string" && line.includes("50%-done")));
+    assert.ok(!logged.some(line => typeof line === "string" && /[\r\n]/.test(line)));
 });
 
 test("throws when none of the PR labels match the required labels", () => {


### PR DESCRIPTION
## Summary
This PR adds escaping of special characters in label names before logging them to prevent potential GitHub Actions workflow command injection vulnerabilities.

## Key Changes
- Added `escapeData()` function calls to three console.log statements in `action.js` that output label names
  - Required labels list
  - Pull request labels list
  - Matching labels list
- Added comprehensive test case to verify that workflow command characters (`\r`, `\n`, `%`) are properly escaped in logged output
- Test validates that escaped characters appear in logs while raw special characters do not

## Implementation Details
The `escapeData()` function escapes characters that could be interpreted as GitHub Actions workflow commands:
- `%` → `%25`
- `\r` → `%0D`
- `\n` → `%0A`

This prevents malicious label names from being interpreted as workflow commands when the logs are processed by GitHub Actions.

https://claude.ai/code/session_01BfssAPi1snawYNqmGkCKQB