### PR TITLE
Populate empty .gitignore with common local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+npm-debug.log*
+.DS_Store


### PR DESCRIPTION
The repository's `.gitignore` existed but was completely empty, so it ignored nothing. This adds the entries relevant to this dependency-free Node action — artifacts that local tooling can still produce:

- `node_modules/` (in case dev dependencies are ever installed locally)
- `npm-debug.log*`
- `.DS_Store`

Part of a repo config cleanup series; `timeout-minutes`, `concurrency`, and the LICENSE year will follow in separate PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_0186n9wvxa7HWJxStd5Hupeh)_