### PR TITLE
Update LICENSE copyright year range to 2023-2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Joakim Sørensen
+Copyright (c) 2023-2026 Joakim Sørensen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The MIT license still said `Copyright (c) 2023`, but the repository has ongoing activity through 2026. This extends the notice to the range `2023-2026` (2023 being the year of the initial commit).

Part of a repo config cleanup series (follows #58); workflow `timeout-minutes` and `concurrency` PRs will follow separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_0186n9wvxa7HWJxStd5Hupeh)_