### PR TITLE
Add timeout-minutes to all workflow jobs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,7 @@ jobs:
   run_the_action:
     name: "Run the action"
     runs-on: ubuntu-slim
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -31,6 +32,7 @@ jobs:
   run_the_action_maximum_matching_labels:
     name: "Run the action (maximum_matching_labels)"
     runs-on: ubuntu-slim
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -47,6 +49,7 @@ jobs:
   run_the_action_inverted:
     name: "Run the action (inverted)"
     runs-on: ubuntu-slim
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -14,6 +14,7 @@ jobs:
   unittest:
     name: "Run unit tests"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Neither workflow set `timeout-minutes`, so a hung job could run for GitHub's 6-hour default before being killed. This adds `timeout-minutes: 5` to every job — the three action-test jobs in `test.yaml` and the unit-test job in `unittest.yaml`. All of them normally finish in well under a minute, so 5 minutes is a generous ceiling.

Part of a repo config cleanup series (follows #58 and #59); a `concurrency` PR will follow separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_0186n9wvxa7HWJxStd5Hupeh)_