### PR TITLE
Add concurrency groups to cancel superseded workflow runs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run_the_action:
     name: "Run the action"

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -10,6 +10,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unittest:
     name: "Run unit tests"


### PR DESCRIPTION
Neither workflow set `concurrency`, so rapid pushes to the same PR left redundant runs queued or executing. This adds a top-level concurrency group to both `test.yaml` and `unittest.yaml`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Each new run for the same workflow and ref cancels the in-progress one. For `unittest.yaml`'s push trigger on `main`, this means a newer push to main cancels the previous main run — standard practice, since the newer commit's result supersedes it.

Final PR in the repo config cleanup series (follows #58, #59, #60).

---
_Generated by [Claude Code](https://claude.ai/code/session_0186n9wvxa7HWJxStd5Hupeh)_