### PR TITLE
Add an Ubuntu runner matrix to the integration test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,13 +26,9 @@ jobs:
       fail-fast: false
       matrix:
         os: &os_matrix
-          - macos-13
-          - macos-latest
           - ubuntu-24.04
           - ubuntu-24.04-arm
           - ubuntu-slim
-          - windows-11-arm
-          - windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -92,7 +88,6 @@ jobs:
 
       - name: Fail if a blocking label is present
         if: steps.blocking.outcome == 'success'
-        shell: bash
         run: |
           echo "::error::A blocking label is present on the pull request."
           exit 1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
+        os: &os_matrix
           - macos-13
           - macos-latest
           - ubuntu-24.04
@@ -53,14 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - macos-13
-          - macos-latest
-          - ubuntu-24.04
-          - ubuntu-24.04-arm
-          - ubuntu-slim
-          - windows-11-arm
-          - windows-latest
+        os: *os_matrix
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -82,14 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - macos-13
-          - macos-latest
-          - ubuntu-24.04
-          - ubuntu-24.04-arm
-          - ubuntu-slim
-          - windows-11-arm
-          - windows-latest
+        os: *os_matrix
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,8 +14,20 @@ permissions: {}
 
 jobs:
   run_the_action:
-    name: "Run the action"
-    runs-on: ubuntu-slim
+    name: "Run the action (${{ matrix.os }})"
+    if: github.event.pull_request.labels[0] != null
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-13
+          - macos-latest
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - ubuntu-slim
+          - windows-11-arm
+          - windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -29,8 +41,20 @@ jobs:
             bugfix, breaking-change, new-feature, dependencies, ci, documentation, internal, refactor
 
   run_the_action_maximum_matching_labels:
-    name: "Run the action (maximum_matching_labels)"
-    runs-on: ubuntu-slim
+    name: "Run the action (maximum_matching_labels, ${{ matrix.os }})"
+    if: github.event.pull_request.labels[0] != null
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-13
+          - macos-latest
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - ubuntu-slim
+          - windows-11-arm
+          - windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -45,8 +69,20 @@ jobs:
           maximum_matching_labels: 1
 
   run_the_action_inverted:
-    name: "Run the action (inverted)"
-    runs-on: ubuntu-slim
+    name: "Run the action (inverted, ${{ matrix.os }})"
+    if: github.event.pull_request.labels[0] != null
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-13
+          - macos-latest
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - ubuntu-slim
+          - windows-11-arm
+          - windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -63,6 +99,7 @@ jobs:
 
       - name: Fail if a blocking label is present
         if: steps.blocking.outcome == 'success'
+        shell: bash
         run: |
           echo "::error::A blocking label is present on the pull request."
           exit 1


### PR DESCRIPTION
## Summary
Runs the integration test workflow (`.github/workflows/test.yaml`) across a
matrix of Ubuntu runners instead of only `ubuntu-slim`, adding architecture
coverage for the action.

## Key Changes
- **Ubuntu runner matrix**: Added an `os` matrix to all three jobs
  (`run_the_action`, `run_the_action_maximum_matching_labels`,
  `run_the_action_inverted`), defined once via a YAML anchor and aliased across
  the jobs so the list cannot drift:
  - `ubuntu-24.04` (x64)
  - `ubuntu-24.04-arm` (arm64)
  - `ubuntu-slim` (x64 slim)

  macOS and Windows GitHub-hosted runners are not available on this repo's plan,
  so the matrix is Ubuntu-only.
- **Label guard**: Added `if: github.event.pull_request.labels[0] != null` to all
  jobs so the whole matrix is skipped when a PR has no labels.
- **Dynamic job names**: Job names include `${{ matrix.os }}` for visibility in
  the checks UI.
- **Non-blocking failures**: `fail-fast: false` so one runner failing does not
  cancel the others.

Only `.github/workflows/test.yaml` changes; `unittest.yaml`, `action.js`, and
`action.yml` are untouched.