### PR TITLE
Add Copilot instructions file

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,9 +26,9 @@ no GitHub API calls, no token — so it runs under `permissions: {}`.
 - **Escape untrusted output.** Any label-derived (user-controlled) string that
   is printed as part of a workflow command (`::error::`, `::warning::`) must go
   through `escapeData()` to prevent workflow-command injection.
-- **Report failure via exit code**, not thrown exceptions: print
-  `::error::<message>` and set `process.exitCode = 1`. The action has no
-  outputs.
+- **Report failure via exit code**: errors may be thrown inside `runAction()`, but must be
+  caught in the entrypoint which prints `::error::<message>` and sets `process.exitCode = 1`.
+  The action has no outputs.
 - **Node 24 / CommonJS.** Match the declared runtime in `action.yml`; use
   `require()`, not ESM imports.
 - **Keep comments to a minimum.** The code should be self-explanatory; only

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,7 +58,7 @@ This is exactly what CI runs. Tests mock `node:fs` and set env vars via the
 - Every PR must carry exactly one change-type label (enforced by the action
   itself in `test.yaml`): `bugfix`, `breaking-change`, `new-feature`,
   `dependencies`, `ci`, `documentation`, `internal`, or `refactor`.
-- These labels drive auto-generated release notes (`.github/release.yml`).
+- A subset of these labels is used to categorize auto-generated release notes (`.github/release.yml`).
 - Releases are SemVer git tags (e.g. `2.0.0`), referenced in the README as
   `ludeeus/action-require-labels@<version>`.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,72 @@
+# action-require-labels
+
+A GitHub Action that fails a workflow run when a pull request is missing
+required labels. It reads labels directly from the workflow event payload —
+no GitHub API calls, no token — so it runs under `permissions: {}`.
+
+## Repository layout
+
+- `action.yml` — action manifest (`runs.using: node24`, `main: action.js`)
+- `action.js` — the entire implementation (CommonJS, exports `runAction`)
+- `action.test.js` — unit tests using the built-in `node:test` runner
+- `.github/workflows/unittest.yaml` — runs `node --test` on PRs/pushes to `main`
+- `.github/workflows/test.yaml` — integration self-test that runs the local
+  action (`uses: ./`) against this repo's own PR labels
+- `.github/release.yml` — release-notes categories, driven by PR labels
+
+## Design constraints (do not break these)
+
+- **Zero third-party dependencies.** Only Node.js built-ins. No `package.json`,
+  no `node_modules`, no build/bundle step — the action ships raw `action.js`.
+  Being auditable in a single read is a stated feature; do not add
+  `@actions/core`, `@actions/github`, or any other package.
+- **No GitHub API or token usage.** All data comes from
+  `process.env.GITHUB_EVENT_PATH` and `INPUT_*` environment variables.
+  Everything must keep working under `permissions: {}`.
+- **Escape untrusted output.** Any label-derived (user-controlled) string that
+  is printed as part of a workflow command (`::error::`, `::warning::`) must go
+  through `escapeData()` to prevent workflow-command injection.
+- **Report failure via exit code**, not thrown exceptions: print
+  `::error::<message>` and set `process.exitCode = 1`. The action has no
+  outputs.
+- **Node 24 / CommonJS.** Match the declared runtime in `action.yml`; use
+  `require()`, not ESM imports.
+- **Keep comments to a minimum.** The code should be self-explanatory; only
+  comment what the code cannot express.
+
+## Testing
+
+Run the full test suite with the built-in Node test runner (no npm install):
+
+    node --test
+
+This is exactly what CI runs. Tests mock `node:fs` and set env vars via the
+`stubEvent()` helper in `action.test.js`; mocks and env are restored in
+`afterEach`. New behavior in `action.js` needs matching coverage in
+`action.test.js`, including failure branches.
+
+## Workflow / CI conventions
+
+- Workflows declare `permissions: {}` at the top level.
+- Third-party actions are pinned to a full commit SHA (with a version
+  comment), and checkouts use `persist-credentials: false`.
+- `test.yaml` dog-foods the action: it must keep passing against the label
+  set used by this repo's PRs.
+
+## Pull requests and releases
+
+- Every PR must carry exactly one change-type label (enforced by the action
+  itself in `test.yaml`): `bugfix`, `breaking-change`, `new-feature`,
+  `dependencies`, `ci`, `documentation`, `internal`, or `refactor`.
+- These labels drive auto-generated release notes (`.github/release.yml`).
+- Releases are SemVer git tags (e.g. `2.0.0`), referenced in the README as
+  `ludeeus/action-require-labels@<version>`.
+
+## Documentation
+
+- `README.md` is the user-facing documentation. Update it when inputs or
+  behavior change, keeping the documented examples (at-least-one,
+  exactly-one via `maximum_matching_labels: 1`, AND via repeated steps,
+  inverted/blocking via `continue-on-error`) accurate.
+- Keep this file (`.github/copilot-instructions.md`) and the README
+  up-to-date whenever the action's behavior, inputs, or conventions change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-.github/copilot-instructions.md


### PR DESCRIPTION
Adds `.github/copilot-instructions.md` so AI coding assistants pick up the repository's conventions instead of guessing them. It documents:

- The repository layout and what the action does
- Design constraints: zero third-party dependencies, no GitHub API/token usage (works under `permissions: {}`), workflow-command escaping via `escapeData()`, failure reported through `::error::` + exit code, Node 24/CommonJS, minimal comments
- Testing with the built-in runner (`node --test`, matching CI)
- Workflow/CI conventions: `permissions: {}`, SHA-pinned actions, the self-test in `test.yaml`
- The change-type PR label requirement and how labels drive release notes
- Keeping the README and this file up to date when behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWCLj5kZDcq6YfGWmHo9hz