### PR TITLE
Add Ubuntu 26.04 to test matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,8 @@ jobs:
         os: &os_matrix
           - ubuntu-24.04
           - ubuntu-24.04-arm
+          - ubuntu-26.04
+          - ubuntu-26.04-arm
           - ubuntu-slim
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
Extended the CI test matrix to include Ubuntu 26.04 (both x86 and ARM architectures) alongside the existing Ubuntu 24.04 variants.

## Changes
- Added `ubuntu-26.04` to the OS matrix in the test workflow
- Added `ubuntu-26.04-arm` to the OS matrix in the test workflow

## Details
This change ensures that the test suite runs against the latest Ubuntu LTS release, providing early validation of compatibility with Ubuntu 26.04 across both standard and ARM-based architectures. The existing Ubuntu 24.04 test configurations are retained for continued coverage.

https://claude.ai/code/session_01Rgt33DAYfHCDFvq8LwBAEq