### PR TITLE
Add CLAUDE.md file referencing copilot instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md


### PR DESCRIPTION
## Summary
Added a CLAUDE.md file that references the GitHub Copilot instructions configuration file.

## Changes
- Created CLAUDE.md with a reference to `.github/copilot-instructions.md`

## Details
This file appears to be a pointer or documentation file that directs to the Copilot-specific instructions stored in the `.github` directory. This is likely part of setting up AI assistant configuration for the repository.

https://claude.ai/code/session_01CcVHLfksdhVPFT2dJJWPi3