### PR TITLE
Add Renovate custom manager for GitHub Actions runner versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,14 @@
   "labels": [
     "dependencies"
   ],
-  "prConcurrentLimit": 10
+  "prConcurrentLimit": 10,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/[^/]+\\.ya?ml$/"],
+      "matchStrings": ["- (?<depName>ubuntu|macos|windows)-(?<currentValue>\\d[^\\s]*)"],
+      "datasourceTemplate": "github-runners",
+      "versioningTemplate": "docker"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
This change adds a custom Renovate manager configuration to automatically detect and update GitHub Actions runner OS versions (ubuntu, macos, windows) in workflow files.

## Key Changes
- Added `customManagers` configuration to `renovate.json`
- Configured regex-based custom manager to:
  - Target GitHub Actions workflow files (`.github/workflows/*.yml` and `.yaml`)
  - Match runner OS version patterns (e.g., `ubuntu-22.04`, `macos-latest`, `windows-2022`)
  - Use `github-runners` datasource for version resolution
  - Apply Docker versioning strategy for version comparison

## Implementation Details
The custom manager uses a regex pattern to extract:
- `depName`: The runner OS name (ubuntu, macos, or windows)
- `currentValue`: The version/tag specified for that runner

This enables Renovate to automatically create pull requests when new runner versions become available, keeping CI/CD workflows up-to-date with the latest available GitHub Actions runner versions.

https://claude.ai/code/session_01WaskKfncbbQ4MkzJ8nvBg4