### PR TITLE
Document ActionError convention for error handling

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,7 +31,7 @@ no GitHub API calls, no token — so it runs under `permissions: {}`.
   instances inside `runAction()` — the `ActionError` class is defined in
   `action.js` and exported alongside `runAction`. The entrypoint catches
   everything and sets `process.exitCode = 1`; the action has no outputs. For an
-  `ActionError` it prints the escaped message via `::error::${escapeData(message)}`;
+  `ActionError` it prints the escaped message via `::error::${escapeData(err.message)}`;
   for any other (unexpected) error it deliberately prints a generic
   `::error::Unknown error`, withholding the message rather than leaking internal
   detail.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,9 +26,15 @@ no GitHub API calls, no token — so it runs under `permissions: {}`.
 - **Escape untrusted output.** Any label-derived (user-controlled) string that
   is printed as part of a workflow command (`::error::`, `::warning::`) must go
   through `escapeData()` to prevent workflow-command injection.
-- **Report failure via exit code**: errors may be thrown inside `runAction()`, but must be
-  caught in the entrypoint which prints `::error::<message>` and sets `process.exitCode = 1`.
-  The action has no outputs.
+- **Report failure via exit code, with the `ActionError` convention**: raise
+  intentional failures (invalid configuration or input) as `ActionError`
+  instances inside `runAction()` — the `ActionError` class is defined in
+  `action.js` and exported alongside `runAction`. The entrypoint catches
+  everything and sets `process.exitCode = 1`; the action has no outputs. For an
+  `ActionError` it prints the escaped message via `::error::${escapeData(message)}`;
+  for any other (unexpected) error it deliberately prints a generic
+  `::error::Unknown error`, withholding the message rather than leaking internal
+  detail.
 - **Node 24 / CommonJS.** Match the declared runtime in `action.yml`; use
   `require()`, not ESM imports.
 - **Keep comments to a minimum.** The code should be self-explanatory; only


### PR DESCRIPTION
## Summary

Updates `.github/copilot-instructions.md` to document the `ActionError` convention for distinguishing intentional failures (invalid configuration/input) from unexpected errors in the action.

## Changes

- **Expanded error-handling guidance** in the "Report failure via exit code" section to introduce the `ActionError` class as the standard way to signal intentional failures
- **Clarified error message handling**: `ActionError` messages are escaped and printed via `::error::`; all other errors print a generic `::error::Unknown error` to avoid leaking internal details
- **Updated documentation** to reflect that `ActionError` is defined in `action.js` and exported alongside `runAction`

## Implementation details

This documents an existing or planned convention where:
- Intentional failures (e.g., missing required labels, invalid configuration) are raised as `ActionError` instances
- The entrypoint catches all errors and sets `process.exitCode = 1`
- User-facing error messages from `ActionError` are properly escaped to prevent workflow-command injection
- Unexpected errors are handled defensively by printing only a generic message, protecting against accidental information disclosure

https://claude.ai/code/session_019u57gBzLRp9V1VKnTvz59a