### PR TITLE
Convert function declarations to arrow functions

### DIFF
--- a/action.js
+++ b/action.js
@@ -4,7 +4,7 @@ const fs = require("node:fs")
 // Anything that is not an ActionError is treated as an unexpected failure.
 class ActionError extends Error {}
 
-function runAction() {
+const runAction = () => {
     const eventPath = process.env.GITHUB_EVENT_PATH
 
     if (!eventPath || !fs.existsSync(eventPath)) {
@@ -74,7 +74,7 @@ const resolveMaximumMatchingLabelsCount = (defaultValue) => {
 
 // Workflow command data must stay on a single line; see
 // https://docs.github.com/actions/reference/workflow-commands-for-github-actions
-function escapeData(data) {
+const escapeData = (data) => {
     return data.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A")
 }
 


### PR DESCRIPTION
Refactor two function declarations in `action.js` to use arrow function syntax, aligning with the project's code style convention of defining helpers as `const` arrow functions.

**Changes:**
- Convert `runAction()` from function declaration to `const runAction = () => { ... }`
- Convert `escapeData(data)` from function declaration to `const escapeData = (data) => { ... }`

This brings the codebase into full compliance with the documented style guide, which specifies that helpers should be defined as `const` arrow functions. Both functions are now consistently styled with other helpers in the file like `resolveMaximumMatchingLabelsCount`.

https://claude.ai/code/session_01VzRMzE2oBBsHoMbZfFoSbW