### PR TITLE
Strengthen comment guidelines in copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,12 +37,15 @@ no GitHub API calls, no token — so it runs under `permissions: {}`.
   detail.
 - **Node 24 / CommonJS.** Match the declared runtime in `action.yml`; use
   `require()`, not ESM imports.
-- **Keep comments in code to a minimum.** Self-explanatory code carries no
-  comment — do not restate what a name, type, or control-flow structure already
-  makes clear. Reserve comments for rationale the code genuinely cannot convey,
-  such as a reference to an external specification. If code needs a comment to
-  be understood, prefer clarifying the code (names, extracted helpers) over
-  adding the comment.
+- **Comments are the exception, not the default.** Do not comment what names,
+  types, and control flow already make clear — delete such comments instead of
+  writing them, and fix unclear code by renaming or extracting a helper, not by
+  annotating it. A comment is justified only to capture what the code cannot: a
+  reference to an external specification, or the non-obvious *why* behind a
+  deliberate choice. Never comment the *what* or the *how*. When in doubt, leave
+  it out. This does not license removing required annotations — e.g. the
+  `# vX.Y.Z` tag on a pinned action SHA (see Workflow / CI conventions) or the
+  workflow-command reference in `escapeData()`.
 
 ## Code style
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,8 +37,12 @@ no GitHub API calls, no token — so it runs under `permissions: {}`.
   detail.
 - **Node 24 / CommonJS.** Match the declared runtime in `action.yml`; use
   `require()`, not ESM imports.
-- **Keep comments to a minimum.** The code should be self-explanatory; only
-  comment what the code cannot express.
+- **Keep comments in code to a minimum.** Self-explanatory code carries no
+  comment — do not restate what a name, type, or control-flow structure already
+  makes clear. Reserve comments for rationale the code genuinely cannot convey,
+  such as a reference to an external specification. If code needs a comment to
+  be understood, prefer clarifying the code (names, extracted helpers) over
+  adding the comment.
 
 ## Code style
 

--- a/action.js
+++ b/action.js
@@ -1,5 +1,7 @@
 const fs = require("node:fs")
 
+// Errors the action raises intentionally for invalid configuration or input.
+// Anything that is not an ActionError is treated as an unexpected failure.
 class ActionError extends Error {}
 
 function runAction() {
@@ -70,6 +72,8 @@ const resolveMaximumMatchingLabelsCount = (defaultValue) => {
     return maximum
 }
 
+// Workflow command data must stay on a single line; see
+// https://docs.github.com/actions/reference/workflow-commands-for-github-actions
 function escapeData(data) {
     return data.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A")
 }

--- a/action.js
+++ b/action.js
@@ -1,7 +1,5 @@
 const fs = require("node:fs")
 
-// Errors the action raises intentionally for invalid configuration or input.
-// Anything that is not an ActionError is treated as an unexpected failure.
 class ActionError extends Error {}
 
 function runAction() {
@@ -72,8 +70,6 @@ const resolveMaximumMatchingLabelsCount = (defaultValue) => {
     return maximum
 }
 
-// Workflow command data must stay on a single line; see
-// https://docs.github.com/actions/reference/workflow-commands-for-github-actions
 function escapeData(data) {
     return data.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A")
 }


### PR DESCRIPTION
## Summary

Strengthens the "comments in code" guideline in `.github/copilot-instructions.md` (which `CLAUDE.md` symlinks to) so it gives firm, unambiguous direction. Documentation only — `action.js` and every other file are unchanged in the net diff.

## Changes

- **`.github/copilot-instructions.md`**: Replaced the soft "Keep comments to a minimum" note with a firmer rule:
  - **Bright line** — comment the non-obvious *why* (or a reference to an external specification); never the *what* or the *how*.
  - **Fix the code, not the comment** — resolve unclear code by renaming or extracting a helper rather than annotating it.
  - **Protects required annotations** — explicitly calls out that the rule does not license stripping the `# vX.Y.Z` tag on a pinned action SHA (per Workflow / CI conventions) or the workflow-command reference in `escapeData()`.

## Notes

Earlier commits on this branch also trimmed two comments from `action.js`, but both were restored — the `escapeData()` comment is exactly the external-specification reference the guideline says to keep. The net effect of this PR is the documentation change above; no behavioral change, and the test suite passes unchanged (`node --test`, 31/31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127qfxn3kyWBBbLLHDMpNgS