### PR TITLE
Clarify escapeData() purpose in copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,9 +23,9 @@ no GitHub API calls, no token — so it runs under `permissions: {}`.
 - **No GitHub API or token usage.** All data comes from
   `process.env.GITHUB_EVENT_PATH` and `INPUT_*` environment variables.
   Everything must keep working under `permissions: {}`.
-- **Escape untrusted output.** Any label-derived (user-controlled) string that
-  is printed as part of a workflow command (`::error::`, `::warning::`) must go
-  through `escapeData()` to prevent workflow-command injection.
+- **Escape label-derived output.** Any label-derived string printed as part of
+  a workflow command (`::error::`, `::warning::`) must go through `escapeData()`
+  so it stays on a single log line.
 - **Report failure via exit code, with the `ActionError` convention**: raise
   intentional failures (invalid configuration or input) as `ActionError`
   instances inside `runAction()` — the `ActionError` class is defined in


### PR DESCRIPTION
Updates the design constraints documentation to better reflect the actual purpose of `escapeData()` in this codebase.

**Summary**

The `escapeData()` requirement in `.github/copilot-instructions.md` has been clarified to focus on its practical effect: keeping log output on a single line, rather than framing it primarily as a security measure against injection attacks.

**Changes**

- Reworded the "Escape untrusted output" constraint to "Escape label-derived output"
- Simplified the explanation to emphasize that escaping ensures output stays on a single log line
- Removed the parenthetical "(user-controlled)" qualifier as it's implicit in "label-derived"
- Condensed the description to fit the actual use case more directly

**Rationale**

The original phrasing emphasized workflow-command injection prevention, but the practical constraint in this zero-dependency, read-only action is simpler: label strings must be escaped when printed in workflow commands to prevent line breaks from fragmenting the log output. This change makes the guidance more actionable and accurate to the codebase's actual needs.

https://claude.ai/code/session_01WUohfDHfwG3CLWi9Bna1zU