### PR TITLE
Replace maximum_matching_labels with flexible require input

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,10 +54,10 @@ no GitHub API calls, no token — so it runs under `permissions: {}`.
   resolved value and assign it to a `const`, rather than seeding a `let` and
   reassigning it.
 - **Use descriptive names for constants and functions.** A name should say what
-  the value or function represents (e.g. `resolveMaximumMatchingLabelsCount`,
-  not `resolveMaximumMatchingLabels`).
+  the value or function represents (e.g. `resolveRequireConstraint`,
+  not `resolveRequire`).
 - **Define helpers as `const` arrow functions**, e.g.
-  `const resolveMaximumMatchingLabelsCount = (defaultValue) => { ... }`.
+  `const resolveRequireConstraint = () => { ... }`.
 
 ## Testing
 
@@ -90,8 +90,8 @@ This is exactly what CI runs. Tests mock `node:fs` and set env vars via the
 ## Documentation
 
 - `README.md` is the user-facing documentation. Update it when inputs or
-  behavior change, keeping the documented examples (at-least-one,
-  exactly-one via `maximum_matching_labels: 1`, AND via repeated steps,
-  inverted/blocking via `continue-on-error`) accurate.
+  behavior change, keeping the documented examples (at-least-one via the
+  default `require: any`, exactly-one via `require: 1`, none/blocking via
+  `require: none`, AND via repeated steps) accurate.
 - Keep this file (`.github/copilot-instructions.md`) and the README
   up-to-date whenever the action's behavior, inputs, or conventions change.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,8 +43,8 @@ jobs:
           labels: >-
             bugfix, breaking-change, new-feature, dependencies, ci, documentation, internal, refactor
 
-  run_the_action_maximum_matching_labels:
-    name: "Run the action (maximum_matching_labels, ${{ matrix.os }})"
+  run_the_action_require_exactly_one:
+    name: "Run the action (require: 1, ${{ matrix.os }})"
     if: github.event.pull_request.labels[0] != null
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
@@ -63,10 +63,10 @@ jobs:
         with:
           labels: >-
             bugfix, breaking-change, new-feature, dependencies, ci, documentation, internal, refactor
-          maximum_matching_labels: 1
+          require: 1
 
-  run_the_action_inverted:
-    name: "Run the action (inverted, ${{ matrix.os }})"
+  run_the_action_require_none:
+    name: "Run the action (require: none, ${{ matrix.os }})"
     if: github.event.pull_request.labels[0] != null
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
@@ -81,15 +81,8 @@ jobs:
           persist-credentials: false
 
       - name: Run the local action
-        id: blocking
-        continue-on-error: true
         uses: ./
         with:
           labels: >-
             do-not-merge, wip, blocked
-
-      - name: Fail if a blocking label is present
-        if: steps.blocking.outcome == 'success'
-        run: |
-          echo "::error::A blocking label is present on the pull request."
-          exit 1
+          require: none

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It is made for maintainers who want to enforce a labeling policy on pull request
 
 - Requiring a change-type label (like `bugfix` or `new-feature`) so generated release notes and changelogs stay accurate.
 - Requiring a triage or size label before a pull request can be reviewed.
-- Blocking merges while labels like `do-not-merge` or `wip` are present (see [inverted usage](#failing-when-any-of-the-labels-exist-inverted)).
+- Blocking merges while labels like `do-not-merge` or `wip` are present (see [`require: none`](#failing-when-any-of-the-labels-exist)).
 
 Add the check as a required status check on your branch to make the labels mandatory before merge.
 
@@ -14,11 +14,11 @@ Add the check as a required status check on your branch to make the labels manda
 
 - **No token, no API calls** — labels are read straight from the workflow event payload, so the action runs with `permissions: {}`.
 - **Zero dependencies** — the entire action is a single small script ([action.js](action.js)) you can audit in one read, with no third-party packages.
-- **Composable** — match any of several labels in one step, combine steps to require [one label from each set](#requiring-one-label-from-each-of-multiple-sets), or [invert the check](#failing-when-any-of-the-labels-exist-inverted) to block labels.
+- **Composable** — match any of several labels in one step, combine steps to require [one label from each set](#requiring-one-label-from-each-of-multiple-sets), or [block labels](#failing-when-any-of-the-labels-exist) with `require: none`.
 
 ## How it works
 
-The action reads the pull request labels from the event payload and succeeds when at least one of the configured labels is present.
+The action reads the pull request labels from the event payload and, by default, succeeds when at least one of the configured labels is present. The [`require`](#require) input changes *how many* of the labels must be present — from "at least one" (the default) to "none", an exact count, or a comparison.
 
 - It only works on `pull_request` events; it fails on any other event.
 - It runs on Node 24, so the runner needs to support the `node24` action runtime.
@@ -29,29 +29,37 @@ The action reads the pull request labels from the event payload and succeeds whe
 
 **Required** Comma separated string of labels to look for.
 
-The check passes when the pull request has **at least one** of the listed labels (OR matching), not all of them. For example, with `bugfix, breaking-change, new-feature`, a pull request labeled with any single one of those passes. It fails only when none of the listed labels are present.
+By default the check passes when the pull request has **at least one** of the listed labels (OR matching), not all of them. For example, with `bugfix, breaking-change, new-feature`, a pull request labeled with any single one of those passes. Use [`require`](#require) to change how many must be present.
 
 Labels are matched against the pull request labels exactly, including casing. Whitespace around each comma-separated entry is ignored. Supplying the same label more than once has no effect on matching, but logs a warning so the duplicates can be cleaned up.
 
-### `maximum_matching_labels`
+### `require`
 
-**Optional** Maximum number of matching labels allowed on the pull request.
+**Optional** How many of the [`labels`](#labels) must be present on the pull request. Defaults to `any`.
 
-The check fails when **more than** this many of the listed labels are present. It defaults to the number of labels supplied in [`labels`](#labels), so it is a no-op unless you set it to a lower value. Combined with the default "at least one" rule, setting it to `1` enforces **exactly one** matching label.
+| Value | Meaning |
+| --- | --- |
+| `any` (default) | **At least one** of the labels must be present. |
+| `none` | **None** of the labels may be present — the check fails if any are (see [blocking](#failing-when-any-of-the-labels-exist)). |
+| `<N>` (e.g. `1`) | **Exactly** `N` of the labels must be present. `1` enforces exactly one. |
+| `<=N` (e.g. `<=2`) | **At most** `N` of the labels may be present (zero is allowed). |
+| `>=N` (e.g. `>=2`) | **At least** `N` of the labels must be present. |
 
-It must be a positive integer.
+The keywords are case-insensitive and surrounding whitespace is ignored. Numbers must be non-negative integers.
+
+> [!NOTE]
+> In YAML a value that starts with `>` is a block-scalar indicator, so `>=N` must be quoted: `require: '>=2'`. `<=N`, plain numbers, and the keywords need no quoting.
 
 ## Behavior
 
 The result is communicated through the step's success or failure; the action has no outputs.
 
-The step **passes** when the pull request has at least one of the configured labels.
+The step **passes** when the number of configured labels present on the pull request satisfies [`require`](#require) (by default, at least one).
 
 The step **fails** when:
 
-- The pull request has none of the configured labels.
-- The pull request has more matching labels than [`maximum_matching_labels`](#maximum_matching_labels) allows.
-- The pull request has no labels at all.
+- Fewer configured labels are present than [`require`](#require) demands (for the default `any`, that means none are present — including when the pull request has no labels at all).
+- More configured labels are present than [`require`](#require) allows (for example any are present when `require: none`).
 - The workflow was not triggered by a `pull_request` event.
 
 ## Example usage
@@ -118,12 +126,12 @@ The example below requires the pull request to have at least one **type** label 
 
 ### Requiring exactly one label
 
-Use [`maximum_matching_labels`](#maximum_matching_labels) to require **exactly one** of the listed labels — for example exactly one priority label.
+Use [`require: 1`](#require) to require **exactly one** of the listed labels — for example exactly one priority label.
 
 <details>
 <summary>More details and example</summary>
 
-The action already requires **at least one** of the listed labels. Setting `maximum_matching_labels: 1` adds the upper bound, so the step passes only when exactly one of the labels is present.
+`require: 1` makes the step pass only when exactly one of the labels is present — it fails both when none are present and when two or more are.
 
 ```yaml
     ...
@@ -133,38 +141,29 @@ The action already requires **at least one** of the listed labels. Setting `maxi
         with:
           labels: >-
               p1, p2, p3
-          maximum_matching_labels: 1
+          require: 1
 ```
 
 </details>
 
-### Failing when any of the labels exist (inverted)
+### Failing when any of the labels exist
 
-Invert the check to fail when **any** of the listed labels are present (for example to block merging on `do-not-merge`, `wip` or `blocked`).
+Use [`require: none`](#require) to fail when **any** of the listed labels are present — for example to block merging on `do-not-merge`, `wip` or `blocked`.
 
 <details>
 <summary>More details and example</summary>
 
-The action passes when the pull request has **at least one** of the listed labels. To invert this — failing when **any** of the labels are present (for example to block merging on `do-not-merge`, `wip` or `blocked`) — run the action with `continue-on-error: true` to capture its outcome, then fail a follow-up step when that outcome was `success`.
-
-When the pull request has no labels at all, the action exits with a failure, so the inverted check correctly passes (no blocking label is present).
+With `require: none` the step fails as soon as one of the listed labels is present, and passes when none are (including when the pull request has no labels at all). No `continue-on-error` or follow-up step is needed.
 
 ```yaml
     ...
     steps:
-      - name: Check for blocking labels
-        id: blocking
-        continue-on-error: true
+      - name: Block on merge-blocking labels
         uses: ludeeus/action-require-labels@2.0.0
         with:
           labels: >-
               do-not-merge, wip, blocked
-
-      - name: Fail if a blocking label is present
-        if: steps.blocking.outcome == 'success'
-        run: |
-          echo "::error::A blocking label is present on the pull request."
-          exit 1
+          require: none
 ```
 
 </details>

--- a/action.js
+++ b/action.js
@@ -20,56 +20,69 @@ const runAction = () => {
     const inputLabels = process.env.INPUT_LABELS
 
     if (!inputLabels) {
-        throw new ActionError("No required labels defined for the action.")
+        throw new ActionError("No labels defined for the action.")
     }
 
     const parsedLabels = inputLabels.split(",").map(label => label.trim()).filter(Boolean)
-    const requiredLabels = new Set(parsedLabels)
+    const labels = new Set(parsedLabels)
 
-    if (requiredLabels.size === 0) {
-        throw new ActionError("No required labels defined for the action.")
+    if (labels.size === 0) {
+        throw new ActionError("No labels defined for the action.")
     }
 
-    if (parsedLabels.length !== requiredLabels.size) {
+    if (parsedLabels.length !== labels.size) {
         console.log("::warning::The labels input contains duplicate labels.")
     }
 
-    const maximumMatchingLabels = resolveMaximumMatchingLabelsCount(requiredLabels.size)
+    const constraint = resolveRequireConstraint()
 
-    if (!eventData.pull_request.labels || eventData.pull_request.labels.length === 0) {
-        throw new ActionError(`No labels defined on the pull request. Required labels: ${Array.from(requiredLabels).join(", ")}.`)
-    }
+    const prLabels = (eventData.pull_request.labels || []).map(label => label.name)
 
-    const prLabels = eventData.pull_request.labels.map(label => label.name)
-
-    console.log(`Required labels (${escapeData(Array.from(requiredLabels).join(", "))})`)
+    console.log(`Labels (${escapeData(Array.from(labels).join(", "))})`)
     console.log(`Pull request labels (${escapeData(prLabels.join(", "))})`)
 
-    const matchingLabels = prLabels.filter(label => requiredLabels.has(label))
-    console.log(`Found ${matchingLabels.length} matching label(s) on the pull request (${escapeData(matchingLabels.join(", "))})`)
-
-    if (matchingLabels.length === 0) {
-        throw new ActionError(`No matching required labels found. Required labels: ${Array.from(requiredLabels).join(", ")}.`)
-    }
-
-    if (matchingLabels.length > maximumMatchingLabels) {
-        throw new ActionError(`Found ${matchingLabels.length} matching label(s), but a maximum of ${maximumMatchingLabels} is allowed.`)
-    }
+    checkMatchingLabelCount(labels, prLabels, constraint)
 }
 
-const resolveMaximumMatchingLabelsCount = (defaultValue) => {
-    const input = (process.env.INPUT_MAXIMUM_MATCHING_LABELS || "").trim()
-    if (!input) {
-        return defaultValue
+const resolveRequireConstraint = () => {
+    const input = (process.env.INPUT_REQUIRE || "").trim().toLowerCase()
+    if (!input || input === "any") {
+        return { minimum: 1, maximum: Infinity }
     }
-    if (!/^\d+$/.test(input)) {
-        throw new ActionError("maximum_matching_labels must be a positive integer.")
+    if (input === "none") {
+        return { minimum: 0, maximum: 0 }
     }
-    const maximum = Number(input)
-    if (!Number.isSafeInteger(maximum) || maximum < 1) {
-        throw new ActionError("maximum_matching_labels must be a positive integer.")
+
+    const comparison = /^(<=|>=)?(\d+)$/.exec(input)
+    if (!comparison) {
+        throw new ActionError("require must be 'any', 'none', a non-negative integer, or a '<=' / '>=' comparison (e.g. '<=2').")
     }
-    return maximum
+
+    const count = Number(comparison[2])
+    if (!Number.isSafeInteger(count)) {
+        throw new ActionError("require must be 'any', 'none', a non-negative integer, or a '<=' / '>=' comparison (e.g. '<=2').")
+    }
+
+    if (comparison[1] === "<=") {
+        return { minimum: 0, maximum: count }
+    }
+    if (comparison[1] === ">=") {
+        return { minimum: count, maximum: Infinity }
+    }
+    return { minimum: count, maximum: count }
+}
+
+const checkMatchingLabelCount = (labels, prLabels, { minimum, maximum }) => {
+    const matchingLabels = prLabels.filter(label => labels.has(label))
+    console.log(`Found ${matchingLabels.length} matching label(s) on the pull request (${escapeData(matchingLabels.join(", "))})`)
+
+    if (matchingLabels.length < minimum) {
+        throw new ActionError(`Found ${matchingLabels.length} matching label(s) on the pull request, but at least ${minimum} of the configured label(s) is required (${Array.from(labels).join(", ")}).`)
+    }
+
+    if (matchingLabels.length > maximum) {
+        throw new ActionError(`Found ${matchingLabels.length} matching label(s) on the pull request (${matchingLabels.join(", ")}), but at most ${maximum} is allowed.`)
+    }
 }
 
 // Workflow command data must stay on a single line; see

--- a/action.test.js
+++ b/action.test.js
@@ -14,7 +14,7 @@ function stubEvent(opts = {}) {
     const exists = "exists" in opts ? opts.exists : true;
     const eventPath = "eventPath" in opts ? opts.eventPath : "/mock/event.json";
     const inputLabels = "inputLabels" in opts ? opts.inputLabels : "bugfix";
-    const maximumMatchingLabels = "maximumMatchingLabels" in opts ? opts.maximumMatchingLabels : undefined;
+    const require = "require" in opts ? opts.require : undefined;
 
     mock.method(fs, "existsSync", () => exists);
     mock.method(fs, "readFileSync", () => JSON.stringify(event));
@@ -31,10 +31,10 @@ function stubEvent(opts = {}) {
         process.env.INPUT_LABELS = inputLabels;
     }
 
-    if (maximumMatchingLabels === undefined) {
-        delete process.env.INPUT_MAXIMUM_MATCHING_LABELS;
+    if (require === undefined) {
+        delete process.env.INPUT_REQUIRE;
     } else {
-        process.env.INPUT_MAXIMUM_MATCHING_LABELS = maximumMatchingLabels;
+        process.env.INPUT_REQUIRE = require;
     }
 }
 
@@ -42,7 +42,7 @@ afterEach(() => {
     mock.restoreAll();
     delete process.env.GITHUB_EVENT_PATH;
     delete process.env.INPUT_LABELS;
-    delete process.env.INPUT_MAXIMUM_MATCHING_LABELS;
+    delete process.env.INPUT_REQUIRE;
 });
 
 test("throws when the event path is not set", () => {
@@ -62,22 +62,22 @@ test("throws when the event is not a pull request", () => {
 
 test("throws when the pull request has no labels property", () => {
     stubEvent({ event: { pull_request: {} }, inputLabels: "bugfix,new-feature" });
-    assert.throws(() => runAction(), /No labels defined on the pull request\. Required labels: bugfix, new-feature\./);
+    assert.throws(() => runAction(), /Found 0 matching label\(s\) on the pull request, but at least 1 of the configured label\(s\) is required \(bugfix, new-feature\)\./);
 });
 
 test("throws when the pull request has an empty labels array", () => {
     stubEvent({ event: { pull_request: { labels: [] } }, inputLabels: "bugfix,new-feature" });
-    assert.throws(() => runAction(), /No labels defined on the pull request\. Required labels: bugfix, new-feature\./);
+    assert.throws(() => runAction(), /Found 0 matching label\(s\) on the pull request, but at least 1 of the configured label\(s\) is required \(bugfix, new-feature\)\./);
 });
 
-test("throws when no required labels are defined for the action", () => {
+test("throws when no labels are defined for the action", () => {
     stubEvent({ inputLabels: undefined });
-    assert.throws(() => runAction(), /No required labels defined for the action\./);
+    assert.throws(() => runAction(), /No labels defined for the action\./);
 });
 
-test("throws when the required labels input contains only whitespace and commas", () => {
+test("throws when the labels input contains only whitespace and commas", () => {
     stubEvent({ inputLabels: " , , " });
-    assert.throws(() => runAction(), /No required labels defined for the action\./);
+    assert.throws(() => runAction(), /No labels defined for the action\./);
 });
 
 test("ignores empty entries in the required labels input", () => {
@@ -138,7 +138,7 @@ test("throws when none of the PR labels match the required labels", () => {
         event: { pull_request: { labels: [{ name: "documentation" }, { name: "question" }] } },
         inputLabels: "bugfix,breaking-change,new-feature",
     });
-    assert.throws(() => runAction(), /No matching required labels found\. Required labels: bugfix, breaking-change, new-feature\./);
+    assert.throws(() => runAction(), /Found 0 matching label\(s\) on the pull request, but at least 1 of the configured label\(s\) is required \(bugfix, breaking-change, new-feature\)\./);
 });
 
 test("failures raised by the action are ActionError instances", () => {
@@ -157,11 +157,11 @@ test("throws a non-ActionError when the event file is not valid JSON", () => {
     assert.throws(() => runAction(), (err) => err instanceof SyntaxError && !(err instanceof ActionError));
 });
 
-test("the maximum_matching_labels limit failure is an ActionError", () => {
+test("the require limit failure is an ActionError", () => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "bugfix" }, { name: "new-feature" }] } },
         inputLabels: "bugfix,breaking-change,new-feature",
-        maximumMatchingLabels: "1",
+        require: "1",
     });
     assert.throws(() => runAction(), ActionError);
 });
@@ -190,78 +190,162 @@ test("passes by default when every supplied label matches (cap defaults to suppl
     assert.doesNotThrow(() => runAction());
 });
 
-test("throws when matching labels exceed maximum_matching_labels", () => {
+test("require: none passes when none of the labels are present", () => {
     stubEvent({
-        event: { pull_request: { labels: [{ name: "bugfix" }, { name: "new-feature" }] } },
-        inputLabels: "bugfix,breaking-change,new-feature",
-        maximumMatchingLabels: "1",
-    });
-    assert.throws(() => runAction(), /Found 2 matching label\(s\), but a maximum of 1 is allowed\./);
-});
-
-test("passes when matching labels equal maximum_matching_labels (boundary, not exceeded)", () => {
-    stubEvent({
-        event: { pull_request: { labels: [{ name: "bugfix" }, { name: "new-feature" }] } },
-        inputLabels: "bugfix,breaking-change,new-feature",
-        maximumMatchingLabels: "2",
+        event: { pull_request: { labels: [{ name: "documentation" }, { name: "question" }] } },
+        inputLabels: "do-not-merge,wip,blocked",
+        require: "none",
     });
     assert.doesNotThrow(() => runAction());
 });
 
-test("passes with maximum_matching_labels of 1 when exactly one label matches", () => {
+test("require: none passes when the pull request has no labels at all", () => {
     stubEvent({
-        event: { pull_request: { labels: [{ name: "bugfix" }, { name: "question" }] } },
-        inputLabels: "bugfix,breaking-change,new-feature",
-        maximumMatchingLabels: "1",
+        event: { pull_request: { labels: [] } },
+        inputLabels: "do-not-merge,wip,blocked",
+        require: "none",
     });
     assert.doesNotThrow(() => runAction());
 });
 
-for (const value of ["abc", "0", "-1", "1.5"]) {
-    test(`throws when maximum_matching_labels is "${value}"`, () => {
-        stubEvent({
-            event: { pull_request: { labels: [{ name: "bugfix" }] } },
-            inputLabels: "bugfix,breaking-change,new-feature",
-            maximumMatchingLabels: value,
-        });
-        assert.throws(() => runAction(), /maximum_matching_labels must be a positive integer\./);
+test("require: none passes when the pull request has no labels property", () => {
+    stubEvent({
+        event: { pull_request: {} },
+        inputLabels: "do-not-merge,wip,blocked",
+        require: "none",
     });
-}
+    assert.doesNotThrow(() => runAction());
+});
 
-for (const { label, value } of [
-    { label: "a digit string that overflows to Infinity", value: "9".repeat(400) },
-    { label: "a value above Number.MAX_SAFE_INTEGER", value: "9007199254740992" },
-]) {
-    test(`throws when maximum_matching_labels is ${label}`, () => {
+test("require: none fails and names the present labels when a listed label is present", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "do-not-merge" }, { name: "wip" }, { name: "question" }] } },
+        inputLabels: "do-not-merge,wip,blocked",
+        require: "none",
+    });
+    assert.throws(() => runAction(), /Found 2 matching label\(s\) on the pull request \(do-not-merge, wip\), but at most 0 is allowed\./);
+});
+
+test("require: none escapes workflow-command characters in label names before logging", () => {
+    const injected = "block%-me\r\n::error::injected";
+    stubEvent({
+        event: { pull_request: { labels: [{ name: injected }] } },
+        inputLabels: injected,
+        require: "none",
+    });
+    const logged = [];
+    mock.method(console, "log", (msg) => logged.push(msg));
+
+    assert.throws(() => runAction());
+
+    assert.ok(logged.some(line => typeof line === "string" && line.includes("block%25-me%0D%0A::error::injected")));
+    assert.ok(!logged.some(line => typeof line === "string" && /[\r\n]/.test(line)));
+});
+
+test("require: an exact count passes when exactly that many labels match", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }, { name: "new-feature" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+        require: "2",
+    });
+    assert.doesNotThrow(() => runAction());
+});
+
+test("require: an exact count fails when fewer labels match", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+        require: "2",
+    });
+    assert.throws(() => runAction(), /Found 1 matching label\(s\) on the pull request, but at least 2 of the configured label\(s\) is required \(bugfix, breaking-change, new-feature\)\./);
+});
+
+test("require: an exact count fails when more labels match", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }, { name: "new-feature" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+        require: "1",
+    });
+    assert.throws(() => runAction(), /Found 2 matching label\(s\) on the pull request \(bugfix, new-feature\), but at most 1 is allowed\./);
+});
+
+test("require: <=N passes when the number of matching labels is within the cap", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }, { name: "new-feature" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+        require: "<=2",
+    });
+    assert.doesNotThrow(() => runAction());
+});
+
+test("require: <=N passes when no labels match at all (lower bound is zero)", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "documentation" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+        require: "<=2",
+    });
+    assert.doesNotThrow(() => runAction());
+});
+
+test("require: <=N fails when the number of matching labels exceeds the cap", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }, { name: "breaking-change" }, { name: "new-feature" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+        require: "<=2",
+    });
+    assert.throws(() => runAction(), /Found 3 matching label\(s\) on the pull request \(bugfix, breaking-change, new-feature\), but at most 2 is allowed\./);
+});
+
+test("require: >=N passes when enough labels match", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }, { name: "breaking-change" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+        require: ">=2",
+    });
+    assert.doesNotThrow(() => runAction());
+});
+
+test("require: >=N fails when too few labels match", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+        require: ">=2",
+    });
+    assert.throws(() => runAction(), /Found 1 matching label\(s\) on the pull request, but at least 2 of the configured label\(s\) is required \(bugfix, breaking-change, new-feature\)\./);
+});
+
+for (const value of ["all", "1.5", "-1", "<1", "> 2", "==2", "<=", "9".repeat(400), "9007199254740992"]) {
+    test(`throws when require is "${value}"`, () => {
         stubEvent({
             event: { pull_request: { labels: [{ name: "bugfix" }] } },
             inputLabels: "bugfix,breaking-change,new-feature",
-            maximumMatchingLabels: value,
+            require: value,
         });
-        assert.throws(() => runAction(), /maximum_matching_labels must be a positive integer\./);
+        assert.throws(() => runAction(), /require must be 'any', 'none', a non-negative integer, or a '<=' \/ '>=' comparison/);
     });
 }
 
 for (const { label, value } of [
     { label: "empty", value: "" },
-    { label: "a single space", value: " " },
-    { label: "only whitespace", value: "            " },
+    { label: "whitespace", value: "   " },
+    { label: "the keyword any", value: "any" },
+    { label: "the keyword any with surrounding whitespace and casing", value: " ANY " },
 ]) {
-    test(`treats ${label} maximum_matching_labels as unset and uses the default`, () => {
+    test(`treats ${label} require as the default at-least-one rule`, () => {
         stubEvent({
-            event: { pull_request: { labels: [{ name: "bugfix" }, { name: "new-feature" }] } },
+            event: { pull_request: { labels: [{ name: "bugfix" }, { name: "question" }] } },
             inputLabels: "bugfix,breaking-change,new-feature",
-            maximumMatchingLabels: value,
+            require: value,
         });
         assert.doesNotThrow(() => runAction());
     });
 }
 
-test("still throws the no-match error when no labels match, regardless of maximum_matching_labels", () => {
+test("resolves the none keyword regardless of casing and surrounding whitespace", () => {
     stubEvent({
-        event: { pull_request: { labels: [{ name: "documentation" }] } },
-        inputLabels: "bugfix,breaking-change,new-feature",
-        maximumMatchingLabels: "1",
+        event: { pull_request: { labels: [{ name: "do-not-merge" }] } },
+        inputLabels: "do-not-merge,wip",
+        require: " None ",
     });
-    assert.throws(() => runAction(), /No matching required labels found\. Required labels: bugfix, breaking-change, new-feature\./);
+    assert.throws(() => runAction(), /but at most 0 is allowed/);
 });

--- a/action.test.js
+++ b/action.test.js
@@ -14,7 +14,7 @@ function stubEvent(opts = {}) {
     const exists = "exists" in opts ? opts.exists : true;
     const eventPath = "eventPath" in opts ? opts.eventPath : "/mock/event.json";
     const inputLabels = "inputLabels" in opts ? opts.inputLabels : "bugfix";
-    const require = "require" in opts ? opts.require : undefined;
+    const requireInput = "require" in opts ? opts.require : undefined;
 
     mock.method(fs, "existsSync", () => exists);
     mock.method(fs, "readFileSync", () => JSON.stringify(event));
@@ -31,10 +31,10 @@ function stubEvent(opts = {}) {
         process.env.INPUT_LABELS = inputLabels;
     }
 
-    if (require === undefined) {
+    if (requireInput === undefined) {
         delete process.env.INPUT_REQUIRE;
     } else {
-        process.env.INPUT_REQUIRE = require;
+        process.env.INPUT_REQUIRE = requireInput;
     }
 }
 

--- a/action.yml
+++ b/action.yml
@@ -4,8 +4,8 @@ inputs:
   labels:
     description: 'Comma separated string of labels to look for.'
     required: true
-  maximum_matching_labels:
-    description: 'Maximum number of matching labels allowed. Defaults to the number of supplied labels.'
+  require:
+    description: "How many of the labels must be present: 'any' (default, at least one), 'none', an exact count (e.g. '1'), or a comparison ('<=2', '>=2')."
     required: false
 runs:
   using: 'node24'


### PR DESCRIPTION
## Summary

Replaces the `maximum_matching_labels` input with a new `require` input that supports multiple constraint modes: `any` (default, at least one), `none` (block labels), exact counts, and comparison operators (`<=N`, `>=N`). This makes the action more flexible for common use cases like enforcing exactly one label or blocking merges on specific labels without workarounds.

## Key Changes

- **New `require` input** in `action.yml` replaces `maximum_matching_labels`
  - Supports keywords: `any` (default), `none`
  - Supports exact counts: `1`, `2`, etc.
  - Supports comparisons: `<=2`, `>=2`
  - Case-insensitive with whitespace trimming

- **Refactored constraint resolution** in `action.js`
  - `resolveMaximumMatchingLabelsCount()` → `resolveRequireConstraint()` returns `{ minimum, maximum }` object
  - New `checkMatchingLabelCount()` function validates against both bounds
  - Removed early failure when PR has no labels; now checked against constraint

- **Improved error messages**
  - Clearer language: "Found N matching label(s)" format
  - Distinguishes between minimum violations ("at least X required") and maximum violations ("at most X allowed")
  - Escapes label names in error output for `require: none` mode

- **Updated tests** with comprehensive coverage for all constraint modes
  - Tests for `require: none` (blocking labels)
  - Tests for exact counts, `<=N`, and `>=N` comparisons
  - Tests for invalid input validation
  - Tests for keyword case-insensitivity and whitespace handling

- **Updated documentation** (README.md, workflows, instructions)
  - Simplified "inverted" blocking pattern: now just `require: none` instead of `continue-on-error` workaround
  - Updated examples for exactly-one enforcement: `require: 1` instead of `maximum_matching_labels: 1`
  - Updated CI workflows to test the new modes

## Implementation Details

- The constraint is represented as `{ minimum, maximum }` bounds, allowing unified validation logic
- `require: any` (or empty/whitespace) defaults to `{ minimum: 1, maximum: Infinity }`
- `require: none` sets `{ minimum: 0, maximum: 0 }` to block all listed labels
- Numeric constraints can be exact (`require: 2` → min=2, max=2), upper-bounded (`require: <=2`), or lower-bounded (`require: >=2`)
- Input validation rejects invalid formats with a clear error message listing accepted patterns

https://claude.ai/code/session_019GNMb43cP3hN1Ruib6BZKS