### PR TITLE
Add optional step summary with configurable output modes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,13 +42,14 @@ no GitHub API calls, no token — so it runs under `permissions: {}`.
   intentional failures for **invalid configuration or input** as `ActionError`
   instances (in `resolveConfiguration()` and the `resolve*` helpers it calls) —
   the `ActionError` class is defined in `action.js` and exported alongside
-  `runAction` and `main`. A failed *check* is not an `ActionError`; it is the
-  returned `failureMessage`. `main()` catches everything and sets
-  `process.exitCode = 1`; the action has no outputs. For a `failureMessage` or an
-  `ActionError` it prints the escaped message via
-  `::error::${escapeData(...)}`; for any other (unexpected) error it deliberately
-  prints a generic `::error::Unknown error`, withholding the message rather than
-  leaking internal detail.
+  `runAction` and `main`. `runAction()` itself never throws for a failed check;
+  it returns the `failureMessage`, and `main()` raises that as an `ActionError`
+  once the summary has been written, so every failure is reported through a
+  single path. That path is `main()`'s catch: it sets `process.exitCode = 1` (the
+  action has no outputs) and, for an `ActionError`, prints the escaped message via
+  `::error::${escapeData(err.message)}`; for any other (unexpected) error it
+  deliberately prints a generic `::error::Unknown error`, withholding the message
+  rather than leaking internal detail.
 - **Node 24 / CommonJS.** Match the declared runtime in `action.yml`; use
   `require()`, not ESM imports.
 - **Comments are the exception, not the default.** Do not comment what names,

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,7 @@ no GitHub API calls, no token — so it runs under `permissions: {}`.
 ## Repository layout
 
 - `action.yml` — action manifest (`runs.using: node24`, `main: action.js`)
-- `action.js` — the entire implementation (CommonJS, exports `runAction`)
+- `action.js` — the entire implementation (CommonJS, exports `runAction` and `main`)
 - `action.test.js` — unit tests using the built-in `node:test` runner
 - `.github/workflows/unittest.yaml` — runs `node --test` on PRs/pushes to `main`
 - `.github/workflows/test.yaml` — integration self-test that runs the local
@@ -25,16 +25,29 @@ no GitHub API calls, no token — so it runs under `permissions: {}`.
   Everything must keep working under `permissions: {}`.
 - **Escape label-derived output.** Any label-derived string printed as part of
   a workflow command (`::error::`, `::warning::`) must go through `escapeData()`
-  so it stays on a single log line.
+  so it stays on a single log line. Escape once, at the point the workflow
+  command is written — never pre-escape a string that the entrypoint will escape
+  again. Any label-derived string written to the optional step summary (a
+  markdown file, not a workflow command) goes through `escapeMarkdown()` instead,
+  so it stays inside a single, unbroken table cell.
+- **Separate the verdict from the side effects.** `runAction()` validates the
+  configuration (via `resolveConfiguration()`) and evaluates the labels, then
+  **returns** a result object whose `failureMessage` is `null` on success or the
+  failure text when the check fails. It performs no file writes and does not
+  throw for a failed check. The root `main()` owns every side effect: it writes
+  the step summary, prints the `::error::` annotation, and sets
+  `process.exitCode`.
 - **Report failure via exit code, with the `ActionError` convention**: raise
-  intentional failures (invalid configuration or input) as `ActionError`
-  instances inside `runAction()` — the `ActionError` class is defined in
-  `action.js` and exported alongside `runAction`. The entrypoint catches
-  everything and sets `process.exitCode = 1`; the action has no outputs. For an
-  `ActionError` it prints the escaped message via `::error::${escapeData(err.message)}`;
-  for any other (unexpected) error it deliberately prints a generic
-  `::error::Unknown error`, withholding the message rather than leaking internal
-  detail.
+  intentional failures for **invalid configuration or input** as `ActionError`
+  instances (in `resolveConfiguration()` and the `resolve*` helpers it calls) —
+  the `ActionError` class is defined in `action.js` and exported alongside
+  `runAction` and `main`. A failed *check* is not an `ActionError`; it is the
+  returned `failureMessage`. `main()` catches everything and sets
+  `process.exitCode = 1`; the action has no outputs. For a `failureMessage` or an
+  `ActionError` it prints the escaped message via
+  `::error::${escapeData(...)}`; for any other (unexpected) error it deliberately
+  prints a generic `::error::Unknown error`, withholding the message rather than
+  leaking internal detail.
 - **Node 24 / CommonJS.** Match the declared runtime in `action.yml`; use
   `require()`, not ESM imports.
 - **Comments are the exception, not the default.** Do not comment what names,

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,6 +9,7 @@ no GitHub API calls, no token — so it runs under `permissions: {}`.
 - `action.yml` — action manifest (`runs.using: node24`, `main: action.js`)
 - `action.js` — the entire implementation (CommonJS, exports `runAction` and `main`)
 - `action.test.js` — unit tests using the built-in `node:test` runner
+- `action.test.js.snapshot` — committed snapshots of the generated step summaries
 - `.github/workflows/unittest.yaml` — runs `node --test` on PRs/pushes to `main`
 - `.github/workflows/test.yaml` — integration self-test that runs the local
   action (`uses: ./`) against this repo's own PR labels
@@ -82,6 +83,18 @@ This is exactly what CI runs. Tests mock `node:fs` and set env vars via the
 `stubEvent()` helper in `action.test.js`; mocks and env are restored in
 `afterEach`. New behavior in `action.js` needs matching coverage in
 `action.test.js`, including failure branches.
+
+The generated step summaries are covered by snapshots in
+`action.test.js.snapshot`, stored verbatim so the file reads as the rendered
+markdown. It is committed and CI verifies against it. After an intentional change
+to the summary output, regenerate it and read the diff before committing:
+
+    node --test --test-update-snapshots
+
+Never regenerate to make a red test pass without checking the diff — a few
+summary tests keep explicit assertions next to the snapshot (no raw `|` in a
+cell, no row broken across lines) precisely so an escaping regression cannot be
+absorbed by a blind refresh.
 
 ## Workflow / CI conventions
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,7 @@ jobs:
         with:
           labels: >-
             bugfix, breaking-change, new-feature, dependencies, ci, documentation, internal, refactor
+          summary: always
 
   run_the_action_maximum_matching_labels:
     name: "Run the action (maximum_matching_labels, ${{ matrix.os }})"

--- a/README.md
+++ b/README.md
@@ -41,9 +41,25 @@ The check fails when **more than** this many of the listed labels are present. I
 
 It must be a positive integer.
 
+### `summary`
+
+**Optional** Controls the summary written to the [GitHub step summary](https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary), so the result is visible in the run UI instead of only in the logs.
+
+The full summary is a table listing the **required**, **present**, and **matched** labels, along with a pass/fail status line. Choose how much to write and when with one of:
+
+| Value | Behavior |
+| --- | --- |
+| `never` | Write nothing. **Default.** |
+| `always` | Write the full table on every run. |
+| `error` | Write the full table only when the check fails — where it is most useful, since it shows which labels were present versus required. |
+| `minimal` | Write only the pass/fail status line (no table) on every run. |
+| `minimal_error` | Write only the pass/fail status line (no table), and only when the check fails. |
+
+The full-table modes (`always`, `error`) also link to this documentation for the action version in use. The value is matched case-insensitively; any other value fails the action. This input has no effect on whether the check itself passes or fails.
+
 ## Behavior
 
-The result is communicated through the step's success or failure; the action has no outputs.
+The result is communicated through the step's success or failure; the action has no outputs. Depending on [`summary`](#summary), it can additionally write a summary of the required, present, and matched labels to the run's step summary.
 
 The step **passes** when the pull request has at least one of the configured labels.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ The full summary is a table listing the **required**, **present**, and **matched
 
 ## Behavior
 
-The result is communicated through the step's success or failure; the action has no outputs. Depending on [`summary`](#summary), it can additionally write a summary of the required, present, and matched labels to the run's step summary.
+The result is communicated through the step's success or failure; the action has no outputs.
+
+If the [`summary`](#summary) option is set, the action can additionally provide a step summary — see that option for the available modes.
 
 The step **passes** when the pull request has at least one of the configured labels.
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ The full summary is a table listing the **required**, **present**, and **matched
 
 | Value | Behavior |
 | --- | --- |
-| `error` | Write the full table only when the check fails — where it is most useful, since it shows which labels were present versus required. **Default.** |
+| `never` | Write nothing. **Default.** |
 | `always` | Write the full table on every run. |
+| `error` | Write the full table only when the check fails — where it is most useful, since it shows which labels were present versus required. |
 | `minimal` | Write only the pass/fail status line (no table) on every run. |
 | `minimal_error` | Write only the pass/fail status line (no table), and only when the check fails. |
-| `never` | Write nothing. |
 
 ## Behavior
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ The full summary is a table listing the **required**, **present**, and **matched
 | `minimal` | Write only the pass/fail status line (no table) on every run. |
 | `minimal_error` | Write only the pass/fail status line (no table), and only when the check fails. |
 
-The full-table modes (`always`, `error`) also link to this documentation for the action version in use. The value is matched case-insensitively; any other value fails the action. This input has no effect on whether the check itself passes or fails.
-
 ## Behavior
 
 The result is communicated through the step's success or failure; the action has no outputs. Depending on [`summary`](#summary), it can additionally write a summary of the required, present, and matched labels to the run's step summary.

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ The full summary is a table listing the **required**, **present**, and **matched
 
 | Value | Behavior |
 | --- | --- |
-| `never` | Write nothing. **Default.** |
+| `error` | Write the full table only when the check fails — where it is most useful, since it shows which labels were present versus required. **Default.** |
 | `always` | Write the full table on every run. |
-| `error` | Write the full table only when the check fails — where it is most useful, since it shows which labels were present versus required. |
 | `minimal` | Write only the pass/fail status line (no table) on every run. |
 | `minimal_error` | Write only the pass/fail status line (no table), and only when the check fails. |
+| `never` | Write nothing. |
 
 ## Behavior
 

--- a/action.js
+++ b/action.js
@@ -122,10 +122,12 @@ const escapeMarkdown = (text) => text
     .replace(/[\\`*_[\]<>&~|]/g, "\\$&")
     .replace(/\r?\n/g, " ")
 
-// Renders a label as a markdown code span. A backslash is literal inside a code
-// span, so a backtick in the label cannot be escaped — the fence is widened past
-// the longest backtick run instead. GFM still requires escaping the table's own
-// pipe delimiter, even within a code span.
+// Renders a label as a markdown code span. A backslash cannot escape a backtick
+// inside a code span, so the fence is widened past the longest backtick run
+// instead. GFM does resolve `\|` while splitting table cells, so the pipe is
+// escaped there — and a literal backslash is doubled first, otherwise a backslash
+// immediately before a pipe would consume that escape and leave the delimiter
+// bare, breaking the row.
 const asCodeSpan = (label) => {
     const content = label.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, " ")
     const backtickRuns = Array.from(content.matchAll(/`+/g), (match) => match[0].length)

--- a/action.js
+++ b/action.js
@@ -161,9 +161,11 @@ const buildSummary = ({ requiredLabels, prLabels, matchingLabels, maximumMatchin
     return ["## Required labels", "", statusLine, "", ...table].join("\n")
 }
 
+// Owns the whole decision, so the mode is never dereferenced for a run that
+// writes nothing — `never` resolves to a null mode.
 const writeSummary = (result) => {
     const summaryPath = process.env.GITHUB_STEP_SUMMARY
-    if (!summaryPath) {
+    if (!summaryPath || !shouldWriteSummary(result.summaryMode, result.failureMessage !== null)) {
         return
     }
     fs.appendFileSync(summaryPath, buildSummary({ ...result, minimal: result.summaryMode.minimal }))
@@ -173,9 +175,7 @@ const main = () => {
     try {
         const result = runAction()
 
-        if (shouldWriteSummary(result.summaryMode, result.failureMessage !== null)) {
-            writeSummary(result)
-        }
+        writeSummary(result)
 
         if (result.failureMessage) {
             throw new ActionError(result.failureMessage)

--- a/action.js
+++ b/action.js
@@ -114,11 +114,12 @@ const resolveSummaryMode = () => {
 
 const shouldWriteSummary = (mode, failed) => mode !== null && (!mode.errorOnly || failed)
 
-// Keeps a label-derived value inside a single, unbroken markdown table cell.
+// Keeps a label-derived value on a single line and rendering as literal text.
+// The value is only ever embedded mid-line, so characters that are markup solely
+// at the start of a line (`#`, `-`, `1.`) cannot take effect and are left alone;
+// everything that can open an inline construct is escaped.
 const escapeMarkdown = (text) => text
-    .replace(/\\/g, "\\\\")
-    .replace(/`/g, "\\`")
-    .replace(/\|/g, "\\|")
+    .replace(/[\\`*_[\]<>&~|]/g, "\\$&")
     .replace(/\r?\n/g, " ")
 
 // Renders a label as a markdown code span. A backslash is literal inside a code

--- a/action.js
+++ b/action.js
@@ -138,8 +138,7 @@ const asCodeSpan = (label) => {
     return `${fence}${padding}${content}${padding}${fence}`
 }
 
-const ACTION_REPOSITORY = "ludeeus/action-require-labels"
-const DOCUMENTATION_LINK = `[${ACTION_REPOSITORY} documentation](https://github.com/${ACTION_REPOSITORY}#readme)`
+const DOCUMENTATION_LINK = "[ludeeus/action-require-labels documentation](https://github.com/ludeeus/action-require-labels#readme)"
 
 const buildSummary = ({ requiredLabels, prLabels, matchingLabels, maximumMatchingLabelsCount, failureMessage, minimal }) => {
     const labelCell = (labels) => labels.length === 0 ? "_(none)_" : labels.map(asCodeSpan).join(", ")

--- a/action.js
+++ b/action.js
@@ -105,7 +105,7 @@ const SUMMARY_MODES = {
 }
 
 const resolveSummaryMode = () => {
-    const name = (process.env.INPUT_SUMMARY || "").trim().toLowerCase() || "never"
+    const name = (process.env.INPUT_SUMMARY || "").trim().toLowerCase() || "error"
     if (!Object.hasOwn(SUMMARY_MODES, name)) {
         throw new ActionError(`summary must be one of: ${Object.keys(SUMMARY_MODES).join(", ")}.`)
     }

--- a/action.js
+++ b/action.js
@@ -5,14 +5,10 @@ const fs = require("node:fs")
 class ActionError extends Error {}
 
 const runAction = () => {
-    const { eventData, requiredLabels, maximumMatchingLabelsCount } = resolveConfiguration()
+    const { eventData, requiredLabels, maximumMatchingLabelsCount, summaryMode } = resolveConfiguration()
     const requiredLabelsList = Array.from(requiredLabels).join(", ")
 
-    if (!eventData.pull_request.labels || eventData.pull_request.labels.length === 0) {
-        throw new ActionError(`No labels defined on the pull request. Required labels: ${requiredLabelsList}.`)
-    }
-
-    const prLabels = eventData.pull_request.labels.map(label => label.name)
+    const prLabels = (eventData.pull_request.labels || []).map(label => label.name)
 
     console.log(`Required labels (${escapeData(requiredLabelsList)})`)
     console.log(`Pull request labels (${escapeData(prLabels.join(", "))})`)
@@ -20,13 +16,22 @@ const runAction = () => {
     const matchingLabels = prLabels.filter(label => requiredLabels.has(label))
     console.log(`Found ${matchingLabels.length} matching label(s) on the pull request (${escapeData(matchingLabels.join(", "))})`)
 
-    if (matchingLabels.length === 0) {
-        throw new ActionError(`No matching required labels found. Required labels: ${requiredLabelsList}.`)
-    }
+    const failureMessage = resolveFailureMessage({ requiredLabelsList, prLabels, matchingLabels, maximumMatchingLabelsCount })
 
-    if (matchingLabels.length > maximumMatchingLabelsCount) {
-        throw new ActionError(`Found ${matchingLabels.length} matching label(s), but a maximum of ${maximumMatchingLabelsCount} is allowed.`)
+    return { summaryMode, requiredLabels, prLabels, matchingLabels, maximumMatchingLabelsCount, failureMessage }
+}
+
+const resolveFailureMessage = ({ requiredLabelsList, prLabels, matchingLabels, maximumMatchingLabelsCount }) => {
+    if (prLabels.length === 0) {
+        return `No labels defined on the pull request. Required labels: ${requiredLabelsList}.`
     }
+    if (matchingLabels.length === 0) {
+        return `No matching required labels found. Required labels: ${requiredLabelsList}.`
+    }
+    if (matchingLabels.length > maximumMatchingLabelsCount) {
+        return `Found ${matchingLabels.length} matching label(s), but a maximum of ${maximumMatchingLabelsCount} is allowed.`
+    }
+    return null
 }
 
 const resolveConfiguration = () => {
@@ -44,8 +49,9 @@ const resolveConfiguration = () => {
 
     const requiredLabels = resolveRequiredLabels()
     const maximumMatchingLabelsCount = resolveMaximumMatchingLabelsCount(requiredLabels.size)
+    const summaryMode = resolveSummaryMode()
 
-    return { eventData, requiredLabels, maximumMatchingLabelsCount }
+    return { eventData, requiredLabels, maximumMatchingLabelsCount, summaryMode }
 }
 
 const resolveRequiredLabels = () => {
@@ -90,9 +96,87 @@ const escapeData = (data) => {
     return data.replace(/%/g, "%25").replace(/\r/g, "%0D").replace(/\n/g, "%0A")
 }
 
-if (require.main === module) {
+const SUMMARY_MODES = {
+    never: null,
+    always: { errorOnly: false, minimal: false },
+    error: { errorOnly: true, minimal: false },
+    minimal: { errorOnly: false, minimal: true },
+    minimal_error: { errorOnly: true, minimal: true },
+}
+
+const resolveSummaryMode = () => {
+    const name = (process.env.INPUT_SUMMARY || "").trim().toLowerCase() || "never"
+    if (!Object.hasOwn(SUMMARY_MODES, name)) {
+        throw new ActionError(`summary must be one of: ${Object.keys(SUMMARY_MODES).join(", ")}.`)
+    }
+    return SUMMARY_MODES[name]
+}
+
+const shouldWriteSummary = (mode, failed) => mode !== null && (!mode.errorOnly || failed)
+
+// Keeps a label-derived value inside a single, unbroken markdown table cell.
+const escapeMarkdown = (text) => text
+    .replace(/\\/g, "\\\\")
+    .replace(/`/g, "\\`")
+    .replace(/\|/g, "\\|")
+    .replace(/\r?\n/g, " ")
+
+// The action's own repository and ref (tag/branch/SHA) from `uses:`, so the
+// summary links to the documentation matching the version in use. Both are
+// unset for a local action (`uses: ./`), where no link is rendered.
+const resolveDocumentationLink = () => {
+    const repository = process.env.GITHUB_ACTION_REPOSITORY
+    const ref = process.env.GITHUB_ACTION_REF
+    if (!repository || !ref) {
+        return null
+    }
+    return `[${repository}@${ref} documentation](https://github.com/${repository}/blob/${ref}/README.md)`
+}
+
+const buildSummary = ({ requiredLabels, prLabels, matchingLabels, maximumMatchingLabelsCount, failureMessage, minimal, documentationLink }) => {
+    const labelCell = (labels) => labels.length === 0 ? "_(none)_" : labels.map(escapeMarkdown).join(", ")
+    const capNote = maximumMatchingLabelsCount < requiredLabels.size ? ` (max ${maximumMatchingLabelsCount} allowed)` : ""
+    const statusLine = failureMessage
+        ? `❌ **Failed** — ${escapeMarkdown(failureMessage)}`
+        : `✅ **Passed** — ${matchingLabels.length} of ${requiredLabels.size} required labels present${capNote}.`
+
+    const table = minimal ? [] : [
+        "| Group | Labels |",
+        "| --- | --- |",
+        `| Required | ${labelCell(Array.from(requiredLabels))} |`,
+        `| Present | ${labelCell(prLabels)} |`,
+        `| Matched | ${labelCell(matchingLabels)} |`,
+        "",
+        ...(documentationLink ? [documentationLink, ""] : []),
+    ]
+
+    return ["## Required labels", "", statusLine, "", ...table].join("\n")
+}
+
+const writeSummary = (result) => {
+    const summaryPath = process.env.GITHUB_STEP_SUMMARY
+    if (!summaryPath) {
+        return
+    }
+    fs.appendFileSync(summaryPath, buildSummary({
+        ...result,
+        minimal: result.summaryMode.minimal,
+        documentationLink: resolveDocumentationLink(),
+    }))
+}
+
+const main = () => {
     try {
-        runAction()
+        const result = runAction()
+
+        if (shouldWriteSummary(result.summaryMode, result.failureMessage !== null)) {
+            writeSummary(result)
+        }
+
+        if (result.failureMessage) {
+            console.log(`::error::${escapeData(result.failureMessage)}`)
+            process.exitCode = 1
+        }
     } catch (err) {
         if (err instanceof ActionError) {
             console.log(`::error::${escapeData(err.message)}`)
@@ -103,4 +187,8 @@ if (require.main === module) {
     }
 }
 
-module.exports = { runAction, ActionError }
+if (require.main === module) {
+    main()
+}
+
+module.exports = { runAction, main, ActionError }

--- a/action.js
+++ b/action.js
@@ -121,6 +121,18 @@ const escapeMarkdown = (text) => text
     .replace(/\|/g, "\\|")
     .replace(/\r?\n/g, " ")
 
+// Renders a label as a markdown code span. A backslash is literal inside a code
+// span, so a backtick in the label cannot be escaped — the fence is widened past
+// the longest backtick run instead. GFM still requires escaping the table's own
+// pipe delimiter, even within a code span.
+const asCodeSpan = (label) => {
+    const content = label.replace(/\|/g, "\\|").replace(/\r?\n/g, " ")
+    const backtickRuns = Array.from(content.matchAll(/`+/g), (match) => match[0].length)
+    const fence = "`".repeat(Math.max(0, ...backtickRuns) + 1)
+    const padding = content.startsWith("`") || content.endsWith("`") ? " " : ""
+    return `${fence}${padding}${content}${padding}${fence}`
+}
+
 // The action's own repository and ref (tag/branch/SHA) from `uses:`, so the
 // summary links to the documentation matching the version in use. Both are
 // unset for a local action (`uses: ./`), where no link is rendered.
@@ -134,7 +146,7 @@ const resolveDocumentationLink = () => {
 }
 
 const buildSummary = ({ requiredLabels, prLabels, matchingLabels, maximumMatchingLabelsCount, failureMessage, minimal, documentationLink }) => {
-    const labelCell = (labels) => labels.length === 0 ? "_(none)_" : labels.map(escapeMarkdown).join(", ")
+    const labelCell = (labels) => labels.length === 0 ? "_(none)_" : labels.map(asCodeSpan).join(", ")
     const capNote = maximumMatchingLabelsCount < requiredLabels.size ? ` (max ${maximumMatchingLabelsCount} allowed)` : ""
     const statusLine = failureMessage
         ? `❌ **Failed** — ${escapeMarkdown(failureMessage)}`

--- a/action.js
+++ b/action.js
@@ -105,7 +105,7 @@ const SUMMARY_MODES = {
 }
 
 const resolveSummaryMode = () => {
-    const name = (process.env.INPUT_SUMMARY || "").trim().toLowerCase() || "error"
+    const name = (process.env.INPUT_SUMMARY || "").trim().toLowerCase() || "never"
     if (!Object.hasOwn(SUMMARY_MODES, name)) {
         throw new ActionError(`summary must be one of: ${Object.keys(SUMMARY_MODES).join(", ")}.`)
     }

--- a/action.js
+++ b/action.js
@@ -133,16 +133,17 @@ const asCodeSpan = (label) => {
     return `${fence}${padding}${content}${padding}${fence}`
 }
 
-// The action's own repository and ref (tag/branch/SHA) from `uses:`, so the
-// summary links to the documentation matching the version in use. Both are
-// unset for a local action (`uses: ./`), where no link is rendered.
+const ACTION_REPOSITORY = "ludeeus/action-require-labels"
+
+// GITHUB_ACTION_REF is the ref (tag/branch/SHA) this action was resolved from in
+// `uses:`, so the summary links to the documentation matching the version in
+// use. It is unset for a local action (`uses: ./`), where no link is rendered.
 const resolveDocumentationLink = () => {
-    const repository = process.env.GITHUB_ACTION_REPOSITORY
     const ref = process.env.GITHUB_ACTION_REF
-    if (!repository || !ref) {
+    if (!ref) {
         return null
     }
-    return `[${repository}@${ref} documentation](https://github.com/${repository}/blob/${ref}/README.md)`
+    return `[${ACTION_REPOSITORY}@${ref} documentation](https://github.com/${ACTION_REPOSITORY}/blob/${ref}/README.md)`
 }
 
 const buildSummary = ({ requiredLabels, prLabels, matchingLabels, maximumMatchingLabelsCount, failureMessage, minimal, documentationLink }) => {

--- a/action.js
+++ b/action.js
@@ -114,13 +114,15 @@ const resolveSummaryMode = () => {
 
 const shouldWriteSummary = (mode, failed) => mode !== null && (!mode.errorOnly || failed)
 
+// CommonMark counts a lone carriage return as a line ending, not just CRLF and
+// LF, so every variant has to collapse or the value escapes its row.
+const collapseLineEndings = (text) => text.replace(/\r\n|[\r\n]/g, " ")
+
 // Keeps a label-derived value on a single line and rendering as literal text.
 // The value is only ever embedded mid-line, so characters that are markup solely
 // at the start of a line (`#`, `-`, `1.`) cannot take effect and are left alone;
 // everything that can open an inline construct is escaped.
-const escapeMarkdown = (text) => text
-    .replace(/[\\`*_[\]<>&~|]/g, "\\$&")
-    .replace(/\r?\n/g, " ")
+const escapeMarkdown = (text) => collapseLineEndings(text.replace(/[\\`*_[\]<>&~|]/g, "\\$&"))
 
 // Renders a label as a markdown code span. A backslash cannot escape a backtick
 // inside a code span, so the fence is widened past the longest backtick run
@@ -129,7 +131,7 @@ const escapeMarkdown = (text) => text
 // immediately before a pipe would consume that escape and leave the delimiter
 // bare, breaking the row.
 const asCodeSpan = (label) => {
-    const content = label.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, " ")
+    const content = collapseLineEndings(label.replace(/\\/g, "\\\\").replace(/\|/g, "\\|"))
     const backtickRuns = Array.from(content.matchAll(/`+/g), (match) => match[0].length)
     const fence = "`".repeat(Math.max(0, ...backtickRuns) + 1)
     const padding = content.startsWith("`") || content.endsWith("`") ? " " : ""
@@ -137,19 +139,9 @@ const asCodeSpan = (label) => {
 }
 
 const ACTION_REPOSITORY = "ludeeus/action-require-labels"
+const DOCUMENTATION_LINK = `[${ACTION_REPOSITORY} documentation](https://github.com/${ACTION_REPOSITORY}#readme)`
 
-// GITHUB_ACTION_REF is the ref (tag/branch/SHA) this action was resolved from in
-// `uses:`, so the summary links to the documentation matching the version in
-// use. It is unset for a local action (`uses: ./`), where no link is rendered.
-const resolveDocumentationLink = () => {
-    const ref = process.env.GITHUB_ACTION_REF
-    if (!ref) {
-        return null
-    }
-    return `[${ACTION_REPOSITORY}@${ref} documentation](https://github.com/${ACTION_REPOSITORY}/blob/${ref}/README.md)`
-}
-
-const buildSummary = ({ requiredLabels, prLabels, matchingLabels, maximumMatchingLabelsCount, failureMessage, minimal, documentationLink }) => {
+const buildSummary = ({ requiredLabels, prLabels, matchingLabels, maximumMatchingLabelsCount, failureMessage, minimal }) => {
     const labelCell = (labels) => labels.length === 0 ? "_(none)_" : labels.map(asCodeSpan).join(", ")
     const capNote = maximumMatchingLabelsCount < requiredLabels.size ? ` (max ${maximumMatchingLabelsCount} allowed)` : ""
     const statusLine = failureMessage
@@ -163,7 +155,8 @@ const buildSummary = ({ requiredLabels, prLabels, matchingLabels, maximumMatchin
         `| Present | ${labelCell(prLabels)} |`,
         `| Matched | ${labelCell(matchingLabels)} |`,
         "",
-        ...(documentationLink ? [documentationLink, ""] : []),
+        DOCUMENTATION_LINK,
+        "",
     ]
 
     return ["## Required labels", "", statusLine, "", ...table].join("\n")
@@ -174,11 +167,7 @@ const writeSummary = (result) => {
     if (!summaryPath) {
         return
     }
-    fs.appendFileSync(summaryPath, buildSummary({
-        ...result,
-        minimal: result.summaryMode.minimal,
-        documentationLink: resolveDocumentationLink(),
-    }))
+    fs.appendFileSync(summaryPath, buildSummary({ ...result, minimal: result.summaryMode.minimal }))
 }
 
 const main = () => {

--- a/action.js
+++ b/action.js
@@ -187,8 +187,7 @@ const main = () => {
         }
 
         if (result.failureMessage) {
-            console.log(`::error::${escapeData(result.failureMessage)}`)
-            process.exitCode = 1
+            throw new ActionError(result.failureMessage)
         }
     } catch (err) {
         if (err instanceof ActionError) {

--- a/action.js
+++ b/action.js
@@ -126,7 +126,7 @@ const escapeMarkdown = (text) => text
 // the longest backtick run instead. GFM still requires escaping the table's own
 // pipe delimiter, even within a code span.
 const asCodeSpan = (label) => {
-    const content = label.replace(/\|/g, "\\|").replace(/\r?\n/g, " ")
+    const content = label.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, " ")
     const backtickRuns = Array.from(content.matchAll(/`+/g), (match) => match[0].length)
     const fence = "`".repeat(Math.max(0, ...backtickRuns) + 1)
     const padding = content.startsWith("`") || content.endsWith("`") ? " " : ""

--- a/action.test.js
+++ b/action.test.js
@@ -24,7 +24,6 @@ function stubEvent(opts = {}) {
     const maximumMatchingLabels = "maximumMatchingLabels" in opts ? opts.maximumMatchingLabels : undefined;
     const summary = "summary" in opts ? opts.summary : undefined;
     const stepSummaryPath = "stepSummaryPath" in opts ? opts.stepSummaryPath : undefined;
-    const actionRepository = "actionRepository" in opts ? opts.actionRepository : undefined;
     const actionRef = "actionRef" in opts ? opts.actionRef : undefined;
 
     mock.method(fs, "existsSync", () => exists);
@@ -60,12 +59,6 @@ function stubEvent(opts = {}) {
         process.env.GITHUB_STEP_SUMMARY = stepSummaryPath;
     }
 
-    if (actionRepository === undefined) {
-        delete process.env.GITHUB_ACTION_REPOSITORY;
-    } else {
-        process.env.GITHUB_ACTION_REPOSITORY = actionRepository;
-    }
-
     if (actionRef === undefined) {
         delete process.env.GITHUB_ACTION_REF;
     } else {
@@ -93,7 +86,6 @@ afterEach(() => {
     delete process.env.INPUT_MAXIMUM_MATCHING_LABELS;
     delete process.env.INPUT_SUMMARY;
     delete process.env.GITHUB_STEP_SUMMARY;
-    delete process.env.GITHUB_ACTION_REPOSITORY;
     delete process.env.GITHUB_ACTION_REF;
     // main() sets process.exitCode on failure; restore it so a failing-run test
     // cannot make the test runner itself exit non-zero.
@@ -644,7 +636,6 @@ test("links the full summary to the docs for the action ref in use", (t) => {
         inputLabels: "bugfix,breaking-change",
         summary: "always",
         stepSummaryPath: "/mock/summary.md",
-        actionRepository: "ludeeus/action-require-labels",
         actionRef: "2.0.0",
     });
     const writes = captureSummary();
@@ -654,7 +645,7 @@ test("links the full summary to the docs for the action ref in use", (t) => {
     t.assert.snapshot(writes[0].data);
 });
 
-test("omits the docs link when the action repository and ref are unset", (t) => {
+test("omits the docs link when the action ref is unset", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "bugfix" }] } },
         inputLabels: "bugfix,breaking-change",
@@ -675,7 +666,6 @@ test("omits the docs link from the minimal summary even when the ref is set", (t
         inputLabels: "bugfix,breaking-change",
         summary: "minimal",
         stepSummaryPath: "/mock/summary.md",
-        actionRepository: "ludeeus/action-require-labels",
         actionRef: "2.0.0",
     });
     const writes = captureSummary();

--- a/action.test.js
+++ b/action.test.js
@@ -374,7 +374,7 @@ test("main() withholds the message for an unexpected error", () => {
     assert.ok(!logged.some(line => typeof line === "string" && line.includes("not json")));
 });
 
-test("does not write a summary on a passing run when the input is unset (defaults to error)", () => {
+test("does not write a summary when the input is unset (defaults to never)", () => {
     stubEvent({ stepSummaryPath: "/mock/summary.md" });
     const writes = captureSummary();
 
@@ -383,7 +383,7 @@ test("does not write a summary on a passing run when the input is unset (default
     assert.equal(writes.length, 0);
 });
 
-test("writes the full table on a failing run when the input is unset (defaults to error)", (t) => {
+test("does not write a summary on a failing run when the input is unset (defaults to never)", () => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "documentation" }] } },
         inputLabels: "bugfix,breaking-change",
@@ -394,8 +394,7 @@ test("writes the full table on a failing run when the input is unset (defaults t
     main();
 
     assert.equal(process.exitCode, 1);
-    assert.equal(writes.length, 1);
-    t.assert.snapshot(writes[0].data);
+    assert.equal(writes.length, 0);
 });
 
 test("does not write a summary when the mode is \"never\"", () => {

--- a/action.test.js
+++ b/action.test.js
@@ -2,7 +2,9 @@ const { test, mock, afterEach } = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 
-const { runAction, ActionError } = require("./action.js");
+const { runAction, main, ActionError } = require("./action.js");
+
+const originalExitCode = process.exitCode;
 
 // Stubs the filesystem and environment that runAction reads. Nothing here
 // touches the real filesystem (fs is mocked) and the env values are
@@ -15,6 +17,10 @@ function stubEvent(opts = {}) {
     const eventPath = "eventPath" in opts ? opts.eventPath : "/mock/event.json";
     const inputLabels = "inputLabels" in opts ? opts.inputLabels : "bugfix";
     const maximumMatchingLabels = "maximumMatchingLabels" in opts ? opts.maximumMatchingLabels : undefined;
+    const summary = "summary" in opts ? opts.summary : undefined;
+    const stepSummaryPath = "stepSummaryPath" in opts ? opts.stepSummaryPath : undefined;
+    const actionRepository = "actionRepository" in opts ? opts.actionRepository : undefined;
+    const actionRef = "actionRef" in opts ? opts.actionRef : undefined;
 
     mock.method(fs, "existsSync", () => exists);
     mock.method(fs, "readFileSync", () => JSON.stringify(event));
@@ -36,6 +42,43 @@ function stubEvent(opts = {}) {
     } else {
         process.env.INPUT_MAXIMUM_MATCHING_LABELS = maximumMatchingLabels;
     }
+
+    if (summary === undefined) {
+        delete process.env.INPUT_SUMMARY;
+    } else {
+        process.env.INPUT_SUMMARY = summary;
+    }
+
+    if (stepSummaryPath === undefined) {
+        delete process.env.GITHUB_STEP_SUMMARY;
+    } else {
+        process.env.GITHUB_STEP_SUMMARY = stepSummaryPath;
+    }
+
+    if (actionRepository === undefined) {
+        delete process.env.GITHUB_ACTION_REPOSITORY;
+    } else {
+        process.env.GITHUB_ACTION_REPOSITORY = actionRepository;
+    }
+
+    if (actionRef === undefined) {
+        delete process.env.GITHUB_ACTION_REF;
+    } else {
+        process.env.GITHUB_ACTION_REF = actionRef;
+    }
+}
+
+// Captures the summary file writes main() performs, so no test touches disk.
+function captureSummary() {
+    const writes = [];
+    mock.method(fs, "appendFileSync", (path, data) => writes.push({ path, data }));
+    return writes;
+}
+
+function captureLog() {
+    const logged = [];
+    mock.method(console, "log", (msg) => logged.push(msg));
+    return logged;
 }
 
 afterEach(() => {
@@ -43,6 +86,13 @@ afterEach(() => {
     delete process.env.GITHUB_EVENT_PATH;
     delete process.env.INPUT_LABELS;
     delete process.env.INPUT_MAXIMUM_MATCHING_LABELS;
+    delete process.env.INPUT_SUMMARY;
+    delete process.env.GITHUB_STEP_SUMMARY;
+    delete process.env.GITHUB_ACTION_REPOSITORY;
+    delete process.env.GITHUB_ACTION_REF;
+    // main() sets process.exitCode on failure; restore it so a failing-run test
+    // cannot make the test runner itself exit non-zero.
+    process.exitCode = originalExitCode;
 });
 
 test("throws when the event path is not set", () => {
@@ -60,14 +110,14 @@ test("throws when the event is not a pull request", () => {
     assert.throws(() => runAction(), /This is not a pull request\./);
 });
 
-test("throws when the pull request has no labels property", () => {
+test("reports a failure when the pull request has no labels property", () => {
     stubEvent({ event: { pull_request: {} }, inputLabels: "bugfix,new-feature" });
-    assert.throws(() => runAction(), /No labels defined on the pull request\. Required labels: bugfix, new-feature\./);
+    assert.equal(runAction().failureMessage, "No labels defined on the pull request. Required labels: bugfix, new-feature.");
 });
 
-test("throws when the pull request has an empty labels array", () => {
+test("reports a failure when the pull request has an empty labels array", () => {
     stubEvent({ event: { pull_request: { labels: [] } }, inputLabels: "bugfix,new-feature" });
-    assert.throws(() => runAction(), /No labels defined on the pull request\. Required labels: bugfix, new-feature\./);
+    assert.equal(runAction().failureMessage, "No labels defined on the pull request. Required labels: bugfix, new-feature.");
 });
 
 test("throws when no required labels are defined for the action", () => {
@@ -85,7 +135,7 @@ test("ignores empty entries in the required labels input", () => {
         event: { pull_request: { labels: [{ name: "new-feature" }] } },
         inputLabels: "bugfix,,new-feature,",
     });
-    assert.doesNotThrow(() => runAction());
+    assert.equal(runAction().failureMessage, null);
 });
 
 test("warns when the same label is supplied multiple times in the input", () => {
@@ -93,10 +143,9 @@ test("warns when the same label is supplied multiple times in the input", () => 
         event: { pull_request: { labels: [{ name: "bugfix" }] } },
         inputLabels: "bugfix,bugfix,new-feature,bugfix,new-feature",
     });
-    const logged = [];
-    mock.method(console, "log", (msg) => logged.push(msg));
+    const logged = captureLog();
 
-    assert.doesNotThrow(() => runAction());
+    assert.equal(runAction().failureMessage, null);
 
     const warnings = logged.filter(line => typeof line === "string" && line.startsWith("::warning::"));
     assert.equal(warnings.length, 1);
@@ -108,10 +157,9 @@ test("does not warn when every supplied label is unique", () => {
         event: { pull_request: { labels: [{ name: "bugfix" }] } },
         inputLabels: "bugfix,breaking-change,new-feature",
     });
-    const logged = [];
-    mock.method(console, "log", (msg) => logged.push(msg));
+    const logged = captureLog();
 
-    assert.doesNotThrow(() => runAction());
+    assert.equal(runAction().failureMessage, null);
 
     const warnings = logged.filter(line => typeof line === "string" && line.startsWith("::warning::"));
     assert.equal(warnings.length, 0);
@@ -122,10 +170,9 @@ test("escapes workflow-command characters in label names before logging", () => 
         event: { pull_request: { labels: [{ name: "50%-done\r\n::error::injected" }] } },
         inputLabels: "50%-done\r\n::error::injected",
     });
-    const logged = [];
-    mock.method(console, "log", (msg) => logged.push(msg));
+    const logged = captureLog();
 
-    assert.doesNotThrow(() => runAction());
+    assert.equal(runAction().failureMessage, null);
 
     const escaped = "50%25-done%0D%0A::error::injected";
     const labelLines = logged.filter(line => typeof line === "string" && line.includes(escaped));
@@ -133,15 +180,15 @@ test("escapes workflow-command characters in label names before logging", () => 
     assert.ok(!logged.some(line => typeof line === "string" && /[\r\n]/.test(line)));
 });
 
-test("throws when none of the PR labels match the required labels", () => {
+test("reports a failure when none of the PR labels match the required labels", () => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "documentation" }, { name: "question" }] } },
         inputLabels: "bugfix,breaking-change,new-feature",
     });
-    assert.throws(() => runAction(), /No matching required labels found\. Required labels: bugfix, breaking-change, new-feature\./);
+    assert.equal(runAction().failureMessage, "No matching required labels found. Required labels: bugfix, breaking-change, new-feature.");
 });
 
-test("failures raised by the action are ActionError instances", () => {
+test("invalid configuration is raised as an ActionError", () => {
     stubEvent({ event: { push: {} } });
     assert.throws(() => runAction(), ActionError);
 });
@@ -157,21 +204,12 @@ test("throws a non-ActionError when the event file is not valid JSON", () => {
     assert.throws(() => runAction(), (err) => err instanceof SyntaxError && !(err instanceof ActionError));
 });
 
-test("the maximum_matching_labels limit failure is an ActionError", () => {
-    stubEvent({
-        event: { pull_request: { labels: [{ name: "bugfix" }, { name: "new-feature" }] } },
-        inputLabels: "bugfix,breaking-change,new-feature",
-        maximumMatchingLabels: "1",
-    });
-    assert.throws(() => runAction(), ActionError);
-});
-
 test("succeeds when at least one PR label matches a required label", () => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "bugfix" }, { name: "question" }] } },
         inputLabels: "bugfix,breaking-change,new-feature",
     });
-    assert.doesNotThrow(() => runAction());
+    assert.equal(runAction().failureMessage, null);
 });
 
 test("trims whitespace around required labels before matching", () => {
@@ -179,7 +217,7 @@ test("trims whitespace around required labels before matching", () => {
         event: { pull_request: { labels: [{ name: "bugfix" }] } },
         inputLabels: " bugfix , breaking-change , new-feature ",
     });
-    assert.doesNotThrow(() => runAction());
+    assert.equal(runAction().failureMessage, null);
 });
 
 test("passes by default when every supplied label matches (cap defaults to supplied count)", () => {
@@ -187,16 +225,16 @@ test("passes by default when every supplied label matches (cap defaults to suppl
         event: { pull_request: { labels: [{ name: "bugfix" }, { name: "breaking-change" }, { name: "new-feature" }] } },
         inputLabels: "bugfix,breaking-change,new-feature",
     });
-    assert.doesNotThrow(() => runAction());
+    assert.equal(runAction().failureMessage, null);
 });
 
-test("throws when matching labels exceed maximum_matching_labels", () => {
+test("reports a failure when matching labels exceed maximum_matching_labels", () => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "bugfix" }, { name: "new-feature" }] } },
         inputLabels: "bugfix,breaking-change,new-feature",
         maximumMatchingLabels: "1",
     });
-    assert.throws(() => runAction(), /Found 2 matching label\(s\), but a maximum of 1 is allowed\./);
+    assert.equal(runAction().failureMessage, "Found 2 matching label(s), but a maximum of 1 is allowed.");
 });
 
 test("passes when matching labels equal maximum_matching_labels (boundary, not exceeded)", () => {
@@ -205,7 +243,7 @@ test("passes when matching labels equal maximum_matching_labels (boundary, not e
         inputLabels: "bugfix,breaking-change,new-feature",
         maximumMatchingLabels: "2",
     });
-    assert.doesNotThrow(() => runAction());
+    assert.equal(runAction().failureMessage, null);
 });
 
 test("passes with maximum_matching_labels of 1 when exactly one label matches", () => {
@@ -214,7 +252,7 @@ test("passes with maximum_matching_labels of 1 when exactly one label matches", 
         inputLabels: "bugfix,breaking-change,new-feature",
         maximumMatchingLabels: "1",
     });
-    assert.doesNotThrow(() => runAction());
+    assert.equal(runAction().failureMessage, null);
 });
 
 for (const value of ["abc", "0", "-1", "1.5"]) {
@@ -253,15 +291,383 @@ for (const { label, value } of [
             inputLabels: "bugfix,breaking-change,new-feature",
             maximumMatchingLabels: value,
         });
-        assert.doesNotThrow(() => runAction());
+        assert.equal(runAction().failureMessage, null);
     });
 }
 
-test("still throws the no-match error when no labels match, regardless of maximum_matching_labels", () => {
+test("still reports the no-match failure when no labels match, regardless of maximum_matching_labels", () => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "documentation" }] } },
         inputLabels: "bugfix,breaking-change,new-feature",
         maximumMatchingLabels: "1",
     });
-    assert.throws(() => runAction(), /No matching required labels found\. Required labels: bugfix, breaking-change, new-feature\./);
+    assert.equal(runAction().failureMessage, "No matching required labels found. Required labels: bugfix, breaking-change, new-feature.");
+});
+
+test("throws when the summary mode is not recognized", () => {
+    stubEvent({ summary: "verbose" });
+    assert.throws(() => runAction(), /summary must be one of: never, always, error, minimal, minimal_error\./);
+});
+
+test("the unrecognized summary mode failure is an ActionError", () => {
+    stubEvent({ summary: "verbose" });
+    assert.throws(() => runAction(), ActionError);
+});
+
+test("main() exits zero and logs no error on a passing run", () => {
+    stubEvent({ event: { pull_request: { labels: [{ name: "bugfix" }] } }, inputLabels: "bugfix" });
+    const logged = captureLog();
+
+    main();
+
+    assert.equal(process.exitCode, originalExitCode);
+    assert.ok(!logged.some(line => typeof line === "string" && line.startsWith("::error::")));
+});
+
+test("main() logs the escaped failure and exits non-zero on a failing run", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "documentation" }] } },
+        inputLabels: "bugfix,breaking-change",
+    });
+    const logged = captureLog();
+
+    main();
+
+    assert.equal(process.exitCode, 1);
+    assert.ok(logged.includes("::error::No matching required labels found. Required labels: bugfix, breaking-change."));
+});
+
+test("main() escapes label-derived characters in the failure annotation", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "question" }] } },
+        inputLabels: "50%-done\r\n::error::injected",
+    });
+    const logged = captureLog();
+
+    main();
+
+    assert.equal(process.exitCode, 1);
+    const errors = logged.filter(line => typeof line === "string" && line.startsWith("::error::"));
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /50%25-done%0D%0A::error::injected/);
+    assert.ok(!/[\r\n]/.test(errors[0]));
+});
+
+test("main() reports an invalid configuration as an escaped ActionError annotation", () => {
+    stubEvent({ event: { push: {} } });
+    const logged = captureLog();
+
+    main();
+
+    assert.equal(process.exitCode, 1);
+    assert.ok(logged.includes("::error::This is not a pull request."));
+});
+
+test("main() withholds the message for an unexpected error", () => {
+    mock.method(fs, "existsSync", () => true);
+    mock.method(fs, "readFileSync", () => "{ not json");
+    process.env.GITHUB_EVENT_PATH = "/mock/event.json";
+    process.env.INPUT_LABELS = "bugfix";
+    const logged = captureLog();
+
+    main();
+
+    assert.equal(process.exitCode, 1);
+    assert.ok(logged.includes("::error::Unknown error"));
+    assert.ok(!logged.some(line => typeof line === "string" && line.includes("not json")));
+});
+
+test("does not write a summary when the input is unset (defaults to never)", () => {
+    stubEvent({ stepSummaryPath: "/mock/summary.md" });
+    const writes = captureSummary();
+
+    main();
+
+    assert.equal(writes.length, 0);
+});
+
+test("does not write a summary when the mode is \"never\"", () => {
+    stubEvent({ summary: "never", stepSummaryPath: "/mock/summary.md" });
+    const writes = captureSummary();
+
+    main();
+
+    assert.equal(writes.length, 0);
+});
+
+test("does not write a summary when \"always\" but GITHUB_STEP_SUMMARY is unset", () => {
+    stubEvent({ summary: "always" });
+    const writes = captureSummary();
+
+    main();
+
+    assert.equal(writes.length, 0);
+});
+
+test("\"always\" writes a passing summary with the three label groups", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }, { name: "question" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+        summary: "always",
+        stepSummaryPath: "/mock/summary.md",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0].path, "/mock/summary.md");
+    const written = writes[0].data;
+    assert.match(written, /## Required labels/);
+    assert.match(written, /✅ \*\*Passed\*\* — 1 of 3 required labels present\./);
+    assert.match(written, /\| Required \| bugfix, breaking-change, new-feature \|/);
+    assert.match(written, /\| Present \| bugfix, question \|/);
+    assert.match(written, /\| Matched \| bugfix \|/);
+});
+
+test("shows the cap in the passing summary only when it constrains", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "p1" }] } },
+        inputLabels: "p1,p2,p3",
+        maximumMatchingLabels: "1",
+        summary: "always",
+        stepSummaryPath: "/mock/summary.md",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    assert.match(writes[0].data, /✅ \*\*Passed\*\* — 1 of 3 required labels present \(max 1 allowed\)\./);
+});
+
+test("omits the cap from the passing summary when it uses the default", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+        summary: "always",
+        stepSummaryPath: "/mock/summary.md",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    assert.doesNotMatch(writes[0].data, /\(max \d+ allowed\)/);
+});
+
+test("\"always\" writes a failing summary and still exits non-zero", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "documentation" }] } },
+        inputLabels: "bugfix,breaking-change",
+        summary: "always",
+        stepSummaryPath: "/mock/summary.md",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    assert.equal(process.exitCode, 1);
+    assert.equal(writes.length, 1);
+    const written = writes[0].data;
+    assert.match(written, /❌ \*\*Failed\*\* — No matching required labels found\./);
+    assert.match(written, /\| Matched \| _\(none\)_ \|/);
+});
+
+test("\"always\" writes an empty Present group when the pull request has no labels", () => {
+    stubEvent({
+        event: { pull_request: { labels: [] } },
+        inputLabels: "bugfix,breaking-change",
+        summary: "always",
+        stepSummaryPath: "/mock/summary.md",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    assert.equal(process.exitCode, 1);
+    assert.match(writes[0].data, /\| Present \| _\(none\)_ \|/);
+});
+
+test("\"always\" writes the summary for the maximum_matching_labels failure", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }, { name: "new-feature" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+        maximumMatchingLabels: "1",
+        summary: "always",
+        stepSummaryPath: "/mock/summary.md",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    assert.equal(process.exitCode, 1);
+    assert.match(writes[0].data, /❌ \*\*Failed\*\* — Found 2 matching label\(s\), but a maximum of 1 is allowed\./);
+});
+
+test("does not write a summary when an invalid configuration prevents the check", () => {
+    stubEvent({ event: { push: {} }, summary: "always", stepSummaryPath: "/mock/summary.md" });
+    const writes = captureSummary();
+
+    main();
+
+    assert.equal(process.exitCode, 1);
+    assert.equal(writes.length, 0);
+});
+
+test("\"error\" does not write a summary on a passing run", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }] } },
+        inputLabels: "bugfix,breaking-change",
+        summary: "error",
+        stepSummaryPath: "/mock/summary.md",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    assert.equal(writes.length, 0);
+});
+
+test("\"error\" writes the full table on a failing run", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "documentation" }] } },
+        inputLabels: "bugfix,breaking-change",
+        summary: "error",
+        stepSummaryPath: "/mock/summary.md",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    assert.equal(writes.length, 1);
+    assert.match(writes[0].data, /❌ \*\*Failed\*\*/);
+    assert.match(writes[0].data, /\| Matched \| _\(none\)_ \|/);
+});
+
+test("\"minimal\" writes only the status line on a passing run", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }] } },
+        inputLabels: "bugfix,breaking-change,new-feature",
+        summary: "minimal",
+        stepSummaryPath: "/mock/summary.md",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    assert.equal(writes.length, 1);
+    const written = writes[0].data;
+    assert.match(written, /## Required labels/);
+    assert.match(written, /✅ \*\*Passed\*\* — 1 of 3 required labels present\./);
+    assert.doesNotMatch(written, /\| Group \| Labels \|/);
+});
+
+test("\"minimal\" writes the status line on a failing run", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "documentation" }] } },
+        inputLabels: "bugfix,breaking-change",
+        summary: "minimal",
+        stepSummaryPath: "/mock/summary.md",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    assert.equal(writes.length, 1);
+    assert.match(writes[0].data, /❌ \*\*Failed\*\*/);
+    assert.doesNotMatch(writes[0].data, /\| Group \| Labels \|/);
+});
+
+test("\"minimal_error\" does not write a summary on a passing run", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }] } },
+        inputLabels: "bugfix,breaking-change",
+        summary: "minimal_error",
+        stepSummaryPath: "/mock/summary.md",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    assert.equal(writes.length, 0);
+});
+
+test("\"minimal_error\" writes only the status line on a failing run", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "documentation" }] } },
+        inputLabels: "bugfix,breaking-change",
+        summary: "minimal_error",
+        stepSummaryPath: "/mock/summary.md",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    assert.equal(writes.length, 1);
+    assert.match(writes[0].data, /❌ \*\*Failed\*\*/);
+    assert.doesNotMatch(writes[0].data, /\| Group \| Labels \|/);
+});
+
+test("escapes markdown-breaking characters in label names within the summary", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "a|b`c\r\nd" }] } },
+        inputLabels: "a|b`c\r\nd",
+        summary: "always",
+        stepSummaryPath: "/mock/summary.md",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    const written = writes[0].data;
+    assert.match(written, /a\\\|b\\`c d/);
+    assert.ok(!written.includes("a|b"));
+    for (const line of written.split("\n")) {
+        assert.ok(!/[\r\n]/.test(line));
+    }
+});
+
+test("links the full summary to the docs for the action ref in use", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }] } },
+        inputLabels: "bugfix,breaking-change",
+        summary: "always",
+        stepSummaryPath: "/mock/summary.md",
+        actionRepository: "ludeeus/action-require-labels",
+        actionRef: "2.0.0",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    assert.match(writes[0].data, /\[ludeeus\/action-require-labels@2\.0\.0 documentation\]\(https:\/\/github\.com\/ludeeus\/action-require-labels\/blob\/2\.0\.0\/README\.md\)/);
+});
+
+test("omits the docs link when the action repository and ref are unset", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }] } },
+        inputLabels: "bugfix,breaking-change",
+        summary: "always",
+        stepSummaryPath: "/mock/summary.md",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    assert.doesNotMatch(writes[0].data, /documentation\]/);
+});
+
+test("omits the docs link from the minimal summary even when the ref is set", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "bugfix" }] } },
+        inputLabels: "bugfix,breaking-change",
+        summary: "minimal",
+        stepSummaryPath: "/mock/summary.md",
+        actionRepository: "ludeeus/action-require-labels",
+        actionRef: "2.0.0",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    assert.doesNotMatch(writes[0].data, /documentation\]/);
 });

--- a/action.test.js
+++ b/action.test.js
@@ -420,9 +420,9 @@ test("\"always\" writes a passing summary with the three label groups", () => {
     const written = writes[0].data;
     assert.match(written, /## Required labels/);
     assert.match(written, /✅ \*\*Passed\*\* — 1 of 3 required labels present\./);
-    assert.match(written, /\| Required \| bugfix, breaking-change, new-feature \|/);
-    assert.match(written, /\| Present \| bugfix, question \|/);
-    assert.match(written, /\| Matched \| bugfix \|/);
+    assert.match(written, /\| Required \| `bugfix`, `breaking-change`, `new-feature` \|/);
+    assert.match(written, /\| Present \| `bugfix`, `question` \|/);
+    assert.match(written, /\| Matched \| `bugfix` \|/);
 });
 
 test("shows the cap in the passing summary only when it constrains", () => {
@@ -619,11 +619,27 @@ test("escapes markdown-breaking characters in label names within the summary", (
     main();
 
     const written = writes[0].data;
-    assert.match(written, /a\\\|b\\`c d/);
+    // The label contains a backtick, so the code-span fence widens to two rather
+    // than backslash-escaping it (a backslash is literal inside a code span).
+    assert.match(written, /``a\\\|b`c d``/);
     assert.ok(!written.includes("a|b"));
     for (const line of written.split("\n")) {
         assert.ok(!/[\r\n]/.test(line));
     }
+});
+
+test("pads the code span when a label starts or ends with a backtick", () => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "`wip`" }] } },
+        inputLabels: "`wip`",
+        summary: "always",
+        stepSummaryPath: "/mock/summary.md",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    assert.match(writes[0].data, /\| Required \| `` `wip` `` \|/);
 });
 
 test("links the full summary to the docs for the action ref in use", () => {

--- a/action.test.js
+++ b/action.test.js
@@ -634,12 +634,15 @@ test("escapes markdown metacharacters in the failing status line", (t) => {
     main();
 
     const statusLine = writes[0].data.split("\n").find(line => line.startsWith("❌"));
-    // Every inline construct the label names could open must arrive escaped, so
-    // the status line renders the label text literally.
+    // Assert against the label-derived message only, with the action's own bold
+    // prefix removed. Not one occurrence may reach it unescaped, so this checks
+    // for the absence of an unescaped metacharacter rather than the presence of
+    // an escaped one -- the latter passes while a second occurrence still leaks.
+    const message = statusLine.replace(/^❌ \*\*Failed\*\* — /, "");
     for (const metacharacter of ["*", "_", "[", "]", "<", ">", "&", "~"]) {
-        assert.ok(!statusLine.includes(metacharacter) || statusLine.includes(`\\${metacharacter}`));
+        assert.doesNotMatch(message, new RegExp(`(?<!\\\\)\\${metacharacter}`));
     }
-    assert.doesNotMatch(statusLine, /\[link\]\(/);
+    assert.doesNotMatch(message, /\[link\]\(/);
     t.assert.snapshot(writes[0].data);
 });
 

--- a/action.test.js
+++ b/action.test.js
@@ -630,6 +630,27 @@ test("escapes markdown-breaking characters in label names within the summary", (
     t.assert.snapshot(written);
 });
 
+test("escapes markdown metacharacters in the failing status line", (t) => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "question" }] } },
+        inputLabels: "*bold*,_em_,[link](http://example.com),<b>html</b>,a&b,~strike~",
+        summary: "always",
+        stepSummaryPath: "/mock/summary.md",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    const statusLine = writes[0].data.split("\n").find(line => line.startsWith("❌"));
+    // Every inline construct the label names could open must arrive escaped, so
+    // the status line renders the label text literally.
+    for (const metacharacter of ["*", "_", "[", "]", "<", ">", "&", "~"]) {
+        assert.ok(!statusLine.includes(metacharacter) || statusLine.includes(`\\${metacharacter}`));
+    }
+    assert.doesNotMatch(statusLine, /\[link\]\(/);
+    t.assert.snapshot(writes[0].data);
+});
+
 test("pads the code span when a label starts or ends with a backtick", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "`wip`" }] } },

--- a/action.test.js
+++ b/action.test.js
@@ -24,7 +24,6 @@ function stubEvent(opts = {}) {
     const maximumMatchingLabels = "maximumMatchingLabels" in opts ? opts.maximumMatchingLabels : undefined;
     const summary = "summary" in opts ? opts.summary : undefined;
     const stepSummaryPath = "stepSummaryPath" in opts ? opts.stepSummaryPath : undefined;
-    const actionRef = "actionRef" in opts ? opts.actionRef : undefined;
 
     mock.method(fs, "existsSync", () => exists);
     mock.method(fs, "readFileSync", () => JSON.stringify(event));
@@ -58,12 +57,6 @@ function stubEvent(opts = {}) {
     } else {
         process.env.GITHUB_STEP_SUMMARY = stepSummaryPath;
     }
-
-    if (actionRef === undefined) {
-        delete process.env.GITHUB_ACTION_REF;
-    } else {
-        process.env.GITHUB_ACTION_REF = actionRef;
-    }
 }
 
 // Captures the summary file writes main() performs, so no test touches disk.
@@ -86,7 +79,6 @@ afterEach(() => {
     delete process.env.INPUT_MAXIMUM_MATCHING_LABELS;
     delete process.env.INPUT_SUMMARY;
     delete process.env.GITHUB_STEP_SUMMARY;
-    delete process.env.GITHUB_ACTION_REF;
     // main() sets process.exitCode on failure; restore it so a failing-run test
     // cannot make the test runner itself exit non-zero.
     process.exitCode = originalExitCode;
@@ -651,6 +643,44 @@ test("escapes markdown metacharacters in the failing status line", (t) => {
     t.assert.snapshot(writes[0].data);
 });
 
+for (const { label, lineEnding } of [
+    { label: "a carriage return and line feed", lineEnding: "\r\n" },
+    { label: "a bare line feed", lineEnding: "\n" },
+    { label: "a bare carriage return", lineEnding: "\r" },
+]) {
+    test(`collapses ${label} in a label so the row stays on one line`, () => {
+        stubEvent({
+            event: { pull_request: { labels: [{ name: `before${lineEnding}after` }] } },
+            inputLabels: `before${lineEnding}after`,
+            summary: "always",
+            stepSummaryPath: "/mock/summary.md",
+        });
+        const writes = captureSummary();
+
+        main();
+
+        const rows = writes[0].data.split("\n").filter(line => line.startsWith("| Required"));
+        assert.equal(rows.length, 1);
+        assert.match(rows[0], /before after/);
+    });
+
+    test(`collapses ${label} in the failing status line`, () => {
+        stubEvent({
+            event: { pull_request: { labels: [{ name: "question" }] } },
+            inputLabels: `before${lineEnding}after`,
+            summary: "always",
+            stepSummaryPath: "/mock/summary.md",
+        });
+        const writes = captureSummary();
+
+        main();
+
+        const statusLines = writes[0].data.split("\n").filter(line => line.startsWith("❌"));
+        assert.equal(statusLines.length, 1);
+        assert.match(statusLines[0], /before after/);
+    });
+}
+
 test("keeps a label with a backslash before a pipe inside a single cell", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "a\\|b" }] } },
@@ -683,22 +713,7 @@ test("pads the code span when a label starts or ends with a backtick", (t) => {
     t.assert.snapshot(writes[0].data);
 });
 
-test("links the full summary to the docs for the action ref in use", (t) => {
-    stubEvent({
-        event: { pull_request: { labels: [{ name: "bugfix" }] } },
-        inputLabels: "bugfix,breaking-change",
-        summary: "always",
-        stepSummaryPath: "/mock/summary.md",
-        actionRef: "2.0.0",
-    });
-    const writes = captureSummary();
-
-    main();
-
-    t.assert.snapshot(writes[0].data);
-});
-
-test("omits the docs link when the action ref is unset", (t) => {
+test("links the full summary to the documentation", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "bugfix" }] } },
         inputLabels: "bugfix,breaking-change",
@@ -709,17 +724,16 @@ test("omits the docs link when the action ref is unset", (t) => {
 
     main();
 
-    assert.doesNotMatch(writes[0].data, /documentation\]/);
+    assert.match(writes[0].data, /\[ludeeus\/action-require-labels documentation\]\(https:\/\/github\.com\/ludeeus\/action-require-labels#readme\)/);
     t.assert.snapshot(writes[0].data);
 });
 
-test("omits the docs link from the minimal summary even when the ref is set", (t) => {
+test("omits the docs link from the minimal summary", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "bugfix" }] } },
         inputLabels: "bugfix,breaking-change",
         summary: "minimal",
         stepSummaryPath: "/mock/summary.md",
-        actionRef: "2.0.0",
     });
     const writes = captureSummary();
 

--- a/action.test.js
+++ b/action.test.js
@@ -651,6 +651,24 @@ test("escapes markdown metacharacters in the failing status line", (t) => {
     t.assert.snapshot(writes[0].data);
 });
 
+test("keeps a label with a backslash before a pipe inside a single cell", (t) => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "a\\|b" }] } },
+        inputLabels: "a\\|b",
+        summary: "always",
+        stepSummaryPath: "/mock/summary.md",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    const row = writes[0].data.split("\n").find(line => line.startsWith("| Required"));
+    // Doubling the backslash keeps the label's pipe escaped, so only the three
+    // cell delimiters remain unescaped and the row cannot split.
+    assert.equal(row.match(/(?<!\\)\|/g).length, 3);
+    t.assert.snapshot(writes[0].data);
+});
+
 test("pads the code span when a label starts or ends with a backtick", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "`wip`" }] } },

--- a/action.test.js
+++ b/action.test.js
@@ -374,13 +374,28 @@ test("main() withholds the message for an unexpected error", () => {
     assert.ok(!logged.some(line => typeof line === "string" && line.includes("not json")));
 });
 
-test("does not write a summary when the input is unset (defaults to never)", () => {
+test("does not write a summary on a passing run when the input is unset (defaults to error)", () => {
     stubEvent({ stepSummaryPath: "/mock/summary.md" });
     const writes = captureSummary();
 
     main();
 
     assert.equal(writes.length, 0);
+});
+
+test("writes the full table on a failing run when the input is unset (defaults to error)", (t) => {
+    stubEvent({
+        event: { pull_request: { labels: [{ name: "documentation" }] } },
+        inputLabels: "bugfix,breaking-change",
+        stepSummaryPath: "/mock/summary.md",
+    });
+    const writes = captureSummary();
+
+    main();
+
+    assert.equal(process.exitCode, 1);
+    assert.equal(writes.length, 1);
+    t.assert.snapshot(writes[0].data);
 });
 
 test("does not write a summary when the mode is \"never\"", () => {

--- a/action.test.js
+++ b/action.test.js
@@ -1,8 +1,13 @@
-const { test, mock, afterEach } = require("node:test");
+const { test, mock, afterEach, snapshot } = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 
 const { runAction, main, ActionError } = require("./action.js");
+
+// Store the generated markdown verbatim, so action.test.js.snapshot reads as the
+// rendered summaries a run would produce. Regenerate with:
+//     node --test --test-update-snapshots
+snapshot.setDefaultSnapshotSerializers([(value) => value]);
 
 const originalExitCode = process.exitCode;
 
@@ -404,7 +409,7 @@ test("does not write a summary when \"always\" but GITHUB_STEP_SUMMARY is unset"
     assert.equal(writes.length, 0);
 });
 
-test("\"always\" writes a passing summary with the three label groups", () => {
+test("\"always\" writes a passing summary with the three label groups", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "bugfix" }, { name: "question" }] } },
         inputLabels: "bugfix,breaking-change,new-feature",
@@ -417,15 +422,10 @@ test("\"always\" writes a passing summary with the three label groups", () => {
 
     assert.equal(writes.length, 1);
     assert.equal(writes[0].path, "/mock/summary.md");
-    const written = writes[0].data;
-    assert.match(written, /## Required labels/);
-    assert.match(written, /✅ \*\*Passed\*\* — 1 of 3 required labels present\./);
-    assert.match(written, /\| Required \| `bugfix`, `breaking-change`, `new-feature` \|/);
-    assert.match(written, /\| Present \| `bugfix`, `question` \|/);
-    assert.match(written, /\| Matched \| `bugfix` \|/);
+    t.assert.snapshot(writes[0].data);
 });
 
-test("shows the cap in the passing summary only when it constrains", () => {
+test("shows the cap in the passing summary only when it constrains", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "p1" }] } },
         inputLabels: "p1,p2,p3",
@@ -437,10 +437,10 @@ test("shows the cap in the passing summary only when it constrains", () => {
 
     main();
 
-    assert.match(writes[0].data, /✅ \*\*Passed\*\* — 1 of 3 required labels present \(max 1 allowed\)\./);
+    t.assert.snapshot(writes[0].data);
 });
 
-test("omits the cap from the passing summary when it uses the default", () => {
+test("omits the cap from the passing summary when it uses the default", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "bugfix" }] } },
         inputLabels: "bugfix,breaking-change,new-feature",
@@ -452,9 +452,10 @@ test("omits the cap from the passing summary when it uses the default", () => {
     main();
 
     assert.doesNotMatch(writes[0].data, /\(max \d+ allowed\)/);
+    t.assert.snapshot(writes[0].data);
 });
 
-test("\"always\" writes a failing summary and still exits non-zero", () => {
+test("\"always\" writes a failing summary and still exits non-zero", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "documentation" }] } },
         inputLabels: "bugfix,breaking-change",
@@ -467,12 +468,10 @@ test("\"always\" writes a failing summary and still exits non-zero", () => {
 
     assert.equal(process.exitCode, 1);
     assert.equal(writes.length, 1);
-    const written = writes[0].data;
-    assert.match(written, /❌ \*\*Failed\*\* — No matching required labels found\./);
-    assert.match(written, /\| Matched \| _\(none\)_ \|/);
+    t.assert.snapshot(writes[0].data);
 });
 
-test("\"always\" writes an empty Present group when the pull request has no labels", () => {
+test("\"always\" writes an empty Present group when the pull request has no labels", (t) => {
     stubEvent({
         event: { pull_request: { labels: [] } },
         inputLabels: "bugfix,breaking-change",
@@ -484,10 +483,10 @@ test("\"always\" writes an empty Present group when the pull request has no labe
     main();
 
     assert.equal(process.exitCode, 1);
-    assert.match(writes[0].data, /\| Present \| _\(none\)_ \|/);
+    t.assert.snapshot(writes[0].data);
 });
 
-test("\"always\" writes the summary for the maximum_matching_labels failure", () => {
+test("\"always\" writes the summary for the maximum_matching_labels failure", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "bugfix" }, { name: "new-feature" }] } },
         inputLabels: "bugfix,breaking-change,new-feature",
@@ -500,7 +499,7 @@ test("\"always\" writes the summary for the maximum_matching_labels failure", ()
     main();
 
     assert.equal(process.exitCode, 1);
-    assert.match(writes[0].data, /❌ \*\*Failed\*\* — Found 2 matching label\(s\), but a maximum of 1 is allowed\./);
+    t.assert.snapshot(writes[0].data);
 });
 
 test("does not write a summary when an invalid configuration prevents the check", () => {
@@ -527,7 +526,7 @@ test("\"error\" does not write a summary on a passing run", () => {
     assert.equal(writes.length, 0);
 });
 
-test("\"error\" writes the full table on a failing run", () => {
+test("\"error\" writes the full table on a failing run", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "documentation" }] } },
         inputLabels: "bugfix,breaking-change",
@@ -539,11 +538,10 @@ test("\"error\" writes the full table on a failing run", () => {
     main();
 
     assert.equal(writes.length, 1);
-    assert.match(writes[0].data, /❌ \*\*Failed\*\*/);
-    assert.match(writes[0].data, /\| Matched \| _\(none\)_ \|/);
+    t.assert.snapshot(writes[0].data);
 });
 
-test("\"minimal\" writes only the status line on a passing run", () => {
+test("\"minimal\" writes only the status line on a passing run", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "bugfix" }] } },
         inputLabels: "bugfix,breaking-change,new-feature",
@@ -555,13 +553,11 @@ test("\"minimal\" writes only the status line on a passing run", () => {
     main();
 
     assert.equal(writes.length, 1);
-    const written = writes[0].data;
-    assert.match(written, /## Required labels/);
-    assert.match(written, /✅ \*\*Passed\*\* — 1 of 3 required labels present\./);
-    assert.doesNotMatch(written, /\| Group \| Labels \|/);
+    assert.doesNotMatch(writes[0].data, /\| Group \| Labels \|/);
+    t.assert.snapshot(writes[0].data);
 });
 
-test("\"minimal\" writes the status line on a failing run", () => {
+test("\"minimal\" writes the status line on a failing run", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "documentation" }] } },
         inputLabels: "bugfix,breaking-change",
@@ -573,8 +569,8 @@ test("\"minimal\" writes the status line on a failing run", () => {
     main();
 
     assert.equal(writes.length, 1);
-    assert.match(writes[0].data, /❌ \*\*Failed\*\*/);
     assert.doesNotMatch(writes[0].data, /\| Group \| Labels \|/);
+    t.assert.snapshot(writes[0].data);
 });
 
 test("\"minimal_error\" does not write a summary on a passing run", () => {
@@ -591,7 +587,7 @@ test("\"minimal_error\" does not write a summary on a passing run", () => {
     assert.equal(writes.length, 0);
 });
 
-test("\"minimal_error\" writes only the status line on a failing run", () => {
+test("\"minimal_error\" writes only the status line on a failing run", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "documentation" }] } },
         inputLabels: "bugfix,breaking-change",
@@ -603,11 +599,11 @@ test("\"minimal_error\" writes only the status line on a failing run", () => {
     main();
 
     assert.equal(writes.length, 1);
-    assert.match(writes[0].data, /❌ \*\*Failed\*\*/);
     assert.doesNotMatch(writes[0].data, /\| Group \| Labels \|/);
+    t.assert.snapshot(writes[0].data);
 });
 
-test("escapes markdown-breaking characters in label names within the summary", () => {
+test("escapes markdown-breaking characters in label names within the summary", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "a|b`c\r\nd" }] } },
         inputLabels: "a|b`c\r\nd",
@@ -619,16 +615,16 @@ test("escapes markdown-breaking characters in label names within the summary", (
     main();
 
     const written = writes[0].data;
-    // The label contains a backtick, so the code-span fence widens to two rather
-    // than backslash-escaping it (a backslash is literal inside a code span).
-    assert.match(written, /``a\\\|b`c d``/);
+    // Invariants the snapshot must never be regenerated away from: no raw pipe
+    // can reach a cell, and no row may break across lines.
     assert.ok(!written.includes("a|b"));
     for (const line of written.split("\n")) {
         assert.ok(!/[\r\n]/.test(line));
     }
+    t.assert.snapshot(written);
 });
 
-test("pads the code span when a label starts or ends with a backtick", () => {
+test("pads the code span when a label starts or ends with a backtick", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "`wip`" }] } },
         inputLabels: "`wip`",
@@ -639,10 +635,10 @@ test("pads the code span when a label starts or ends with a backtick", () => {
 
     main();
 
-    assert.match(writes[0].data, /\| Required \| `` `wip` `` \|/);
+    t.assert.snapshot(writes[0].data);
 });
 
-test("links the full summary to the docs for the action ref in use", () => {
+test("links the full summary to the docs for the action ref in use", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "bugfix" }] } },
         inputLabels: "bugfix,breaking-change",
@@ -655,10 +651,10 @@ test("links the full summary to the docs for the action ref in use", () => {
 
     main();
 
-    assert.match(writes[0].data, /\[ludeeus\/action-require-labels@2\.0\.0 documentation\]\(https:\/\/github\.com\/ludeeus\/action-require-labels\/blob\/2\.0\.0\/README\.md\)/);
+    t.assert.snapshot(writes[0].data);
 });
 
-test("omits the docs link when the action repository and ref are unset", () => {
+test("omits the docs link when the action repository and ref are unset", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "bugfix" }] } },
         inputLabels: "bugfix,breaking-change",
@@ -670,9 +666,10 @@ test("omits the docs link when the action repository and ref are unset", () => {
     main();
 
     assert.doesNotMatch(writes[0].data, /documentation\]/);
+    t.assert.snapshot(writes[0].data);
 });
 
-test("omits the docs link from the minimal summary even when the ref is set", () => {
+test("omits the docs link from the minimal summary even when the ref is set", (t) => {
     stubEvent({
         event: { pull_request: { labels: [{ name: "bugfix" }] } },
         inputLabels: "bugfix,breaking-change",
@@ -686,4 +683,5 @@ test("omits the docs link from the minimal summary even when the ref is set", ()
     main();
 
     assert.doesNotMatch(writes[0].data, /documentation\]/);
+    t.assert.snapshot(writes[0].data);
 });

--- a/action.test.js.snapshot
+++ b/action.test.js.snapshot
@@ -170,3 +170,16 @@ exports[`shows the cap in the passing summary only when it constrains 1`] = `
 | Matched | \`p1\` |
 
 `;
+
+exports[`writes the full table on a failing run when the input is unset (defaults to error) 1`] = `
+## Required labels
+
+❌ **Failed** — No matching required labels found. Required labels: bugfix, breaking-change.
+
+| Group | Labels |
+| --- | --- |
+| Required | \`bugfix\`, \`breaking-change\` |
+| Present | \`documentation\` |
+| Matched | _(none)_ |
+
+`;

--- a/action.test.js.snapshot
+++ b/action.test.js.snapshot
@@ -9,6 +9,8 @@ exports[`\"always\" writes a failing summary and still exits non-zero 1`] = `
 | Present | \`documentation\` |
 | Matched | _(none)_ |
 
+[ludeeus/action-require-labels documentation](https://github.com/ludeeus/action-require-labels#readme)
+
 `;
 
 exports[`\"always\" writes a passing summary with the three label groups 1`] = `
@@ -21,6 +23,8 @@ exports[`\"always\" writes a passing summary with the three label groups 1`] = `
 | Required | \`bugfix\`, \`breaking-change\`, \`new-feature\` |
 | Present | \`bugfix\`, \`question\` |
 | Matched | \`bugfix\` |
+
+[ludeeus/action-require-labels documentation](https://github.com/ludeeus/action-require-labels#readme)
 
 `;
 
@@ -35,6 +39,8 @@ exports[`\"always\" writes an empty Present group when the pull request has no l
 | Present | _(none)_ |
 | Matched | _(none)_ |
 
+[ludeeus/action-require-labels documentation](https://github.com/ludeeus/action-require-labels#readme)
+
 `;
 
 exports[`\"always\" writes the summary for the maximum_matching_labels failure 1`] = `
@@ -48,6 +54,8 @@ exports[`\"always\" writes the summary for the maximum_matching_labels failure 1
 | Present | \`bugfix\`, \`new-feature\` |
 | Matched | \`bugfix\`, \`new-feature\` |
 
+[ludeeus/action-require-labels documentation](https://github.com/ludeeus/action-require-labels#readme)
+
 `;
 
 exports[`\"error\" writes the full table on a failing run 1`] = `
@@ -60,6 +68,8 @@ exports[`\"error\" writes the full table on a failing run 1`] = `
 | Required | \`bugfix\`, \`breaking-change\` |
 | Present | \`documentation\` |
 | Matched | _(none)_ |
+
+[ludeeus/action-require-labels documentation](https://github.com/ludeeus/action-require-labels#readme)
 
 `;
 
@@ -95,6 +105,8 @@ exports[`escapes markdown metacharacters in the failing status line 1`] = `
 | Present | \`question\` |
 | Matched | _(none)_ |
 
+[ludeeus/action-require-labels documentation](https://github.com/ludeeus/action-require-labels#readme)
+
 `;
 
 exports[`escapes markdown-breaking characters in label names within the summary 1`] = `
@@ -107,6 +119,8 @@ exports[`escapes markdown-breaking characters in label names within the summary 
 | Required | \`\`a\\|b\`c d\`\` |
 | Present | \`\`a\\|b\`c d\`\` |
 | Matched | \`\`a\\|b\`c d\`\` |
+
+[ludeeus/action-require-labels documentation](https://github.com/ludeeus/action-require-labels#readme)
 
 `;
 
@@ -121,9 +135,11 @@ exports[`keeps a label with a backslash before a pipe inside a single cell 1`] =
 | Present | \`a\\\\\\|b\` |
 | Matched | \`a\\\\\\|b\` |
 
+[ludeeus/action-require-labels documentation](https://github.com/ludeeus/action-require-labels#readme)
+
 `;
 
-exports[`links the full summary to the docs for the action ref in use 1`] = `
+exports[`links the full summary to the documentation 1`] = `
 ## Required labels
 
 ✅ **Passed** — 1 of 2 required labels present.
@@ -134,7 +150,7 @@ exports[`links the full summary to the docs for the action ref in use 1`] = `
 | Present | \`bugfix\` |
 | Matched | \`bugfix\` |
 
-[ludeeus/action-require-labels@2.0.0 documentation](https://github.com/ludeeus/action-require-labels/blob/2.0.0/README.md)
+[ludeeus/action-require-labels documentation](https://github.com/ludeeus/action-require-labels#readme)
 
 `;
 
@@ -149,25 +165,14 @@ exports[`omits the cap from the passing summary when it uses the default 1`] = `
 | Present | \`bugfix\` |
 | Matched | \`bugfix\` |
 
-`;
-
-exports[`omits the docs link from the minimal summary even when the ref is set 1`] = `
-## Required labels
-
-✅ **Passed** — 1 of 2 required labels present.
+[ludeeus/action-require-labels documentation](https://github.com/ludeeus/action-require-labels#readme)
 
 `;
 
-exports[`omits the docs link when the action ref is unset 1`] = `
+exports[`omits the docs link from the minimal summary 1`] = `
 ## Required labels
 
 ✅ **Passed** — 1 of 2 required labels present.
-
-| Group | Labels |
-| --- | --- |
-| Required | \`bugfix\`, \`breaking-change\` |
-| Present | \`bugfix\` |
-| Matched | \`bugfix\` |
 
 `;
 
@@ -182,6 +187,8 @@ exports[`pads the code span when a label starts or ends with a backtick 1`] = `
 | Present | \`\` \`wip\` \`\` |
 | Matched | \`\` \`wip\` \`\` |
 
+[ludeeus/action-require-labels documentation](https://github.com/ludeeus/action-require-labels#readme)
+
 `;
 
 exports[`shows the cap in the passing summary only when it constrains 1`] = `
@@ -194,5 +201,7 @@ exports[`shows the cap in the passing summary only when it constrains 1`] = `
 | Required | \`p1\`, \`p2\`, \`p3\` |
 | Present | \`p1\` |
 | Matched | \`p1\` |
+
+[ludeeus/action-require-labels documentation](https://github.com/ludeeus/action-require-labels#readme)
 
 `;

--- a/action.test.js.snapshot
+++ b/action.test.js.snapshot
@@ -170,16 +170,3 @@ exports[`shows the cap in the passing summary only when it constrains 1`] = `
 | Matched | \`p1\` |
 
 `;
-
-exports[`writes the full table on a failing run when the input is unset (defaults to error) 1`] = `
-## Required labels
-
-❌ **Failed** — No matching required labels found. Required labels: bugfix, breaking-change.
-
-| Group | Labels |
-| --- | --- |
-| Required | \`bugfix\`, \`breaking-change\` |
-| Present | \`documentation\` |
-| Matched | _(none)_ |
-
-`;

--- a/action.test.js.snapshot
+++ b/action.test.js.snapshot
@@ -110,6 +110,19 @@ exports[`escapes markdown-breaking characters in label names within the summary 
 
 `;
 
+exports[`keeps a label with a backslash before a pipe inside a single cell 1`] = `
+## Required labels
+
+✅ **Passed** — 1 of 1 required labels present.
+
+| Group | Labels |
+| --- | --- |
+| Required | \`a\\\\\\|b\` |
+| Present | \`a\\\\\\|b\` |
+| Matched | \`a\\\\\\|b\` |
+
+`;
+
 exports[`links the full summary to the docs for the action ref in use 1`] = `
 ## Required labels
 

--- a/action.test.js.snapshot
+++ b/action.test.js.snapshot
@@ -132,7 +132,7 @@ exports[`omits the docs link from the minimal summary even when the ref is set 1
 
 `;
 
-exports[`omits the docs link when the action repository and ref are unset 1`] = `
+exports[`omits the docs link when the action ref is unset 1`] = `
 ## Required labels
 
 ✅ **Passed** — 1 of 2 required labels present.

--- a/action.test.js.snapshot
+++ b/action.test.js.snapshot
@@ -84,6 +84,19 @@ exports[`\"minimal_error\" writes only the status line on a failing run 1`] = `
 
 `;
 
+exports[`escapes markdown metacharacters in the failing status line 1`] = `
+## Required labels
+
+❌ **Failed** — No matching required labels found. Required labels: \\*bold\\*, \\_em\\_, \\[link\\](http://example.com), \\<b\\>html\\</b\\>, a\\&b, \\~strike\\~.
+
+| Group | Labels |
+| --- | --- |
+| Required | \`*bold*\`, \`_em_\`, \`[link](http://example.com)\`, \`<b>html</b>\`, \`a&b\`, \`~strike~\` |
+| Present | \`question\` |
+| Matched | _(none)_ |
+
+`;
+
 exports[`escapes markdown-breaking characters in label names within the summary 1`] = `
 ## Required labels
 

--- a/action.test.js.snapshot
+++ b/action.test.js.snapshot
@@ -1,0 +1,172 @@
+exports[`\"always\" writes a failing summary and still exits non-zero 1`] = `
+## Required labels
+
+❌ **Failed** — No matching required labels found. Required labels: bugfix, breaking-change.
+
+| Group | Labels |
+| --- | --- |
+| Required | \`bugfix\`, \`breaking-change\` |
+| Present | \`documentation\` |
+| Matched | _(none)_ |
+
+`;
+
+exports[`\"always\" writes a passing summary with the three label groups 1`] = `
+## Required labels
+
+✅ **Passed** — 1 of 3 required labels present.
+
+| Group | Labels |
+| --- | --- |
+| Required | \`bugfix\`, \`breaking-change\`, \`new-feature\` |
+| Present | \`bugfix\`, \`question\` |
+| Matched | \`bugfix\` |
+
+`;
+
+exports[`\"always\" writes an empty Present group when the pull request has no labels 1`] = `
+## Required labels
+
+❌ **Failed** — No labels defined on the pull request. Required labels: bugfix, breaking-change.
+
+| Group | Labels |
+| --- | --- |
+| Required | \`bugfix\`, \`breaking-change\` |
+| Present | _(none)_ |
+| Matched | _(none)_ |
+
+`;
+
+exports[`\"always\" writes the summary for the maximum_matching_labels failure 1`] = `
+## Required labels
+
+❌ **Failed** — Found 2 matching label(s), but a maximum of 1 is allowed.
+
+| Group | Labels |
+| --- | --- |
+| Required | \`bugfix\`, \`breaking-change\`, \`new-feature\` |
+| Present | \`bugfix\`, \`new-feature\` |
+| Matched | \`bugfix\`, \`new-feature\` |
+
+`;
+
+exports[`\"error\" writes the full table on a failing run 1`] = `
+## Required labels
+
+❌ **Failed** — No matching required labels found. Required labels: bugfix, breaking-change.
+
+| Group | Labels |
+| --- | --- |
+| Required | \`bugfix\`, \`breaking-change\` |
+| Present | \`documentation\` |
+| Matched | _(none)_ |
+
+`;
+
+exports[`\"minimal\" writes only the status line on a passing run 1`] = `
+## Required labels
+
+✅ **Passed** — 1 of 3 required labels present.
+
+`;
+
+exports[`\"minimal\" writes the status line on a failing run 1`] = `
+## Required labels
+
+❌ **Failed** — No matching required labels found. Required labels: bugfix, breaking-change.
+
+`;
+
+exports[`\"minimal_error\" writes only the status line on a failing run 1`] = `
+## Required labels
+
+❌ **Failed** — No matching required labels found. Required labels: bugfix, breaking-change.
+
+`;
+
+exports[`escapes markdown-breaking characters in label names within the summary 1`] = `
+## Required labels
+
+✅ **Passed** — 1 of 1 required labels present.
+
+| Group | Labels |
+| --- | --- |
+| Required | \`\`a\\|b\`c d\`\` |
+| Present | \`\`a\\|b\`c d\`\` |
+| Matched | \`\`a\\|b\`c d\`\` |
+
+`;
+
+exports[`links the full summary to the docs for the action ref in use 1`] = `
+## Required labels
+
+✅ **Passed** — 1 of 2 required labels present.
+
+| Group | Labels |
+| --- | --- |
+| Required | \`bugfix\`, \`breaking-change\` |
+| Present | \`bugfix\` |
+| Matched | \`bugfix\` |
+
+[ludeeus/action-require-labels@2.0.0 documentation](https://github.com/ludeeus/action-require-labels/blob/2.0.0/README.md)
+
+`;
+
+exports[`omits the cap from the passing summary when it uses the default 1`] = `
+## Required labels
+
+✅ **Passed** — 1 of 3 required labels present.
+
+| Group | Labels |
+| --- | --- |
+| Required | \`bugfix\`, \`breaking-change\`, \`new-feature\` |
+| Present | \`bugfix\` |
+| Matched | \`bugfix\` |
+
+`;
+
+exports[`omits the docs link from the minimal summary even when the ref is set 1`] = `
+## Required labels
+
+✅ **Passed** — 1 of 2 required labels present.
+
+`;
+
+exports[`omits the docs link when the action repository and ref are unset 1`] = `
+## Required labels
+
+✅ **Passed** — 1 of 2 required labels present.
+
+| Group | Labels |
+| --- | --- |
+| Required | \`bugfix\`, \`breaking-change\` |
+| Present | \`bugfix\` |
+| Matched | \`bugfix\` |
+
+`;
+
+exports[`pads the code span when a label starts or ends with a backtick 1`] = `
+## Required labels
+
+✅ **Passed** — 1 of 1 required labels present.
+
+| Group | Labels |
+| --- | --- |
+| Required | \`\` \`wip\` \`\` |
+| Present | \`\` \`wip\` \`\` |
+| Matched | \`\` \`wip\` \`\` |
+
+`;
+
+exports[`shows the cap in the passing summary only when it constrains 1`] = `
+## Required labels
+
+✅ **Passed** — 1 of 3 required labels present (max 1 allowed).
+
+| Group | Labels |
+| --- | --- |
+| Required | \`p1\`, \`p2\`, \`p3\` |
+| Present | \`p1\` |
+| Matched | \`p1\` |
+
+`;

--- a/action.yml
+++ b/action.yml
@@ -10,11 +10,12 @@ inputs:
   summary:
     description: >-
       When to write a summary of the required, present, and matched labels to
-      the GitHub step summary. One of: never (default), always (full table on
-      every run), error (full table only on failure), minimal (status line
-      only, on every run), minimal_error (status line only, only on failure).
+      the GitHub step summary. One of: error (default, full table only on
+      failure), always (full table on every run), minimal (status line only, on
+      every run), minimal_error (status line only, only on failure), never (no
+      summary).
     required: false
-    default: 'never'
+    default: 'error'
 runs:
   using: 'node24'
   main: 'action.js'

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,14 @@ inputs:
   maximum_matching_labels:
     description: 'Maximum number of matching labels allowed. Defaults to the number of supplied labels.'
     required: false
+  summary:
+    description: >-
+      When to write a summary of the required, present, and matched labels to
+      the GitHub step summary. One of: never (default), always (full table on
+      every run), error (full table only on failure), minimal (status line
+      only, on every run), minimal_error (status line only, only on failure).
+    required: false
+    default: 'never'
 runs:
   using: 'node24'
   main: 'action.js'

--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,8 @@ inputs:
     description: >-
       When to write a summary of the required, present, and matched labels to
       the GitHub step summary. One of: never (default), always (full table on
-      every run), error (full table only on failure), minimal (status line
-      only, on every run), minimal_error (status line only, only on failure).
+      every run), error (full table on failure only), minimal (status line only,
+      on every run), minimal_error (status line only, on failure only).
     required: false
     default: 'never'
 runs:

--- a/action.yml
+++ b/action.yml
@@ -10,12 +10,11 @@ inputs:
   summary:
     description: >-
       When to write a summary of the required, present, and matched labels to
-      the GitHub step summary. One of: error (default, full table only on
-      failure), always (full table on every run), minimal (status line only, on
-      every run), minimal_error (status line only, only on failure), never (no
-      summary).
+      the GitHub step summary. One of: never (default), always (full table on
+      every run), error (full table only on failure), minimal (status line
+      only, on every run), minimal_error (status line only, only on failure).
     required: false
-    default: 'error'
+    default: 'never'
 runs:
   using: 'node24'
   main: 'action.js'


### PR DESCRIPTION
Adds an optional `summary` input that writes a markdown table to the GitHub step summary, making the label check result visible in the run UI. The summary is configurable via five modes controlling when and how much detail to write.

## Changes

- **New `summary` input**: Controls step summary output with modes `never` (default), `always`, `error`, `minimal`, and `minimal_error`
  - `never`: Write nothing (preserves current behavior)
  - `always`: Write full table on every run
  - `error`: Write full table on failure only
  - `minimal`: Write only the status line on every run
  - `minimal_error`: Write only the status line on failure only

- **Refactored `runAction()` to return a result object** instead of throwing on check failure
  - Returns `{ summaryMode, requiredLabels, prLabels, matchingLabels, maximumMatchingLabelsCount, failureMessage }`
  - `failureMessage` is `null` on success, or the failure text when the check fails
  - Performs no side effects (file writes, exit code changes)

- **New `main()` entrypoint** that owns all side effects
  - Calls `runAction()` to get the result
  - Writes the step summary if the configured mode calls for it
  - Raises the `failureMessage` as an `ActionError` once the summary is written, so every failure is reported through a single path
  - That path is `main()`'s catch: it prints the escaped `::error::` annotation and sets `process.exitCode = 1`
  - Withholds error details for unexpected errors (non-`ActionError`), printing a generic `::error::Unknown error`

- **Summary generation and markdown escaping**
  - `buildSummary()` renders a table with Required/Present/Matched label groups and a pass/fail status line
  - `escapeMarkdown()` escapes the label-derived failure message embedded in the status line, covering every character that can open an inline construct (`` \ ` * _ [ ] < > & ~ | ``). Characters that are markup only at the start of a line (`#`, `-`, `1.`) are left alone, since the value is always embedded mid-line
  - `asCodeSpan()` renders labels in table cells as markdown code spans, widening the backtick fence past the longest backtick run and padding when a label starts or ends with a backtick. Pipes are escaped (GFM resolves `\|` when splitting cells) with literal backslashes doubled first, so a backslash before a pipe cannot leave the delimiter bare and break the row
  - `collapseLineEndings()` collapses CRLF, LF **and** a bare CR — CommonMark counts a lone carriage return as a line ending, so all three would otherwise break out of a row or status line
  - Full summaries (`always`, `error`) append a link to this repository's README

- **Comprehensive test coverage** with snapshot tests
  - 35 new tests covering all summary modes, edge cases (empty label sets, markdown metacharacters, every line-ending variant, backslash-before-pipe, backtick-delimited labels) and failure scenarios
  - Snapshot file (`action.test.js.snapshot`) stores the rendered summaries verbatim, so it reads as the markdown a run produces; regenerate with `node --test --test-update-snapshots`
  - Assertions that guard invariants rather than appearance sit alongside the snapshots (no raw pipe reaching a cell, no row split across lines, no table in the minimal modes), so an escaping regression cannot be absorbed by regenerating a snapshot

- **Updated documentation and workflows**
  - `README.md` documents the new input with a behavior table
  - `action.yml` declares the new input
  - `.github/copilot-instructions.md` records the verdict/side-effect split, the `escapeMarkdown()` convention, and the snapshot workflow
  - Integration test workflow (`test.yaml`) uses `summary: always` to validate the feature

## Implementation notes

- Label-derived strings in workflow commands (e.g. `::error::`) are escaped via `escapeData()` (existing behavior), escaped once at the point the command is written — never pre-escaped
- Label-derived strings in markdown summaries use different escaping for their context: `escapeMarkdown()` for the status line, `asCodeSpan()` for table cells
- The summary is written to `GITHUB_STEP_SUMMARY` (GitHub Actions standard) via `fs.appendFileSync()`
- Configuration validation (including the new `summary` mode) raises `ActionError` from `resolveConfiguration()` and the `resolve*` helpers it calls; `ActionError` is now reserved for invalid configuration or input, while a failed check travels as the returned `failureMessage`
- The documentation link is a constant pointing at this repository, so no untrusted value is interpolated into it
- All tests mock `fs` and environment variables; no real filesystem access

https://claude.ai/code/session_01PnmHdwb8E3vFfh74ZLcxvB